### PR TITLE
Implementa modo sigiloso y bloqueo de desinstalación

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ BizonMDM es un servicio MDM (Mobile Device Management) para dispositivos Android
 - **Servicios en segundo plano** utilizando `WorkManager` y un `Service` dedicado.
 - **Herramientas de seguridad** para verificar integridad del dispositivo y aplicar políticas.
 - **Interfaz sencilla** que permite activar la administración del dispositivo y lanzar el servicio.
+- **Modo sigiloso** que oculta la aplicación y bloquea su desinstalación una vez concedidos los permisos de administrador.
 
 ## Estructura del proyecto
 
@@ -28,6 +29,6 @@ El proyecto requiere un mínimo de **Android 7.0 (API 24)**.
 
 1. Instala la aplicación en el dispositivo.
 2. Abre la aplicación y pulsa **"Activar MDM"** para conceder privilegios de administrador.
-3. Una vez concedidos los permisos, el servicio se iniciará y podrás ver el estado en pantalla.
+3. Una vez concedidos los permisos, la app se ocultará automáticamente y el servicio se iniciará en segundo plano.
 
 

--- a/app/src/main/java/com/example/mdmjive/receivers/MDMDeviceAdminReceiver.kt
+++ b/app/src/main/java/com/example/mdmjive/receivers/MDMDeviceAdminReceiver.kt
@@ -6,6 +6,8 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.content.pm.PackageManager
+import com.example.mdmjive.MainActivity
 import android.util.Log
 
 class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
@@ -14,6 +16,7 @@ class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
         super.onEnabled(context, intent)
         Log.d("MDM", "Admin enabled")
         setupDeviceAdmin(context)
+        hideLauncherIcon(context)
     }
 
     // Configura el dispositivo con las políticas de administración
@@ -44,6 +47,8 @@ class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
                 setPasswordQuality(componentName, DevicePolicyManager.PASSWORD_QUALITY_COMPLEX)
                 setMaximumFailedPasswordsForWipe(componentName, 10)
                 setMaximumTimeToLock(componentName, 30000L) // 30 segundos de bloqueo
+                // Bloquear la desinstalación de la propia app
+                setUninstallBlocked(componentName, packageName, true)
             }
             Log.d("MDM", "Políticas aplicadas correctamente.")
         } catch (e: Exception) {
@@ -66,6 +71,12 @@ class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
         }
     }
 
+    // Muestra un mensaje cuando el usuario intenta desactivar la administración
+    override fun onDisableRequested(context: Context, intent: Intent): CharSequence? {
+        Log.d("MDM", "Admin disable requested")
+        return "Para salir utiliza el panel administrativo"
+    }
+
     // Este método se llama cuando el dispositivo pierde la administración
     override fun onDisabled(context: Context, intent: Intent) {
         super.onDisabled(context, intent)
@@ -83,5 +94,16 @@ class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK
         }
         context.startActivity(intent)
+    }
+
+    // Deshabilita el icono del lanzador para ocultar la aplicación
+    private fun hideLauncherIcon(context: Context) {
+        val packageManager = context.packageManager
+        val component = ComponentName(context, MainActivity::class.java)
+        packageManager.setComponentEnabledSetting(
+            component,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.DONT_KILL_APP
+        )
     }
 }


### PR DESCRIPTION
## Summary
- ocultar el ícono de la app cuando se concede la administración
- impedir desinstalación con `setUninstallBlocked`
- mostrar mensaje si se intenta desactivar la administración
- documentar el nuevo modo sigiloso en README

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848caf2abe4832f8d109d8866588c97