### PR TITLE
Add device restrictions to PolicyManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ BizonMDM es un servicio MDM (Mobile Device Management) para dispositivos Android
 - **Herramientas de seguridad** para verificar integridad del dispositivo y aplicar políticas.
 - **Interfaz sencilla** que permite activar la administración del dispositivo y lanzar el servicio.
 - **Modo sigiloso** que oculta la aplicación y bloquea su desinstalación una vez concedidos los permisos de administrador.
+- **Restricciones de dispositivo** que impiden el formateo, fijan el brillo al 100%, mantienen el GPS activo y evitan cambios manuales de fecha y hora.
 
 ## Estructura del proyecto
 

--- a/app/src/main/java/com/example/mdmjive/receivers/MDMDeviceAdminReceiver.kt
+++ b/app/src/main/java/com/example/mdmjive/receivers/MDMDeviceAdminReceiver.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.content.pm.PackageManager
 import com.example.mdmjive.MainActivity
 import android.util.Log
+import com.example.mdmjive.security.PolicyManager
 
 class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
 
@@ -27,7 +28,7 @@ class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
         // Verifica si la app es propietaria del dispositivo
         if (dpm.isDeviceOwnerApp(context.packageName)) {
             Log.d("MDM", "La app es propietaria del dispositivo. Aplicando políticas.")
-            applyPolicies(dpm, componentName)
+            applyPolicies(context, dpm, componentName)
             startMDMService(context)
         } else {
             Log.e("MDM", "La app no es propietaria del dispositivo.")
@@ -35,7 +36,7 @@ class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
     }
 
     // Aplica las políticas de seguridad en el dispositivo
-    private fun applyPolicies(dpm: DevicePolicyManager, componentName: ComponentName) {
+    private fun applyPolicies(context: Context, dpm: DevicePolicyManager, componentName: ComponentName) {
         try {
             // Aplicando las políticas
             dpm.apply {
@@ -50,6 +51,11 @@ class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
                 // Bloquear la desinstalación de la propia app
                 setUninstallBlocked(componentName, packageName, true)
             }
+            val policyManager = PolicyManager(context)
+            policyManager.disableFactoryReset()
+            policyManager.lockBrightness()
+            policyManager.lockGPS()
+            policyManager.lockDateTime()
             Log.d("MDM", "Políticas aplicadas correctamente.")
         } catch (e: Exception) {
             Log.e("MDM", "Error aplicando políticas: ${e.message}")

--- a/app/src/main/java/com/example/mdmjive/security/PolicyManager.kt
+++ b/app/src/main/java/com/example/mdmjive/security/PolicyManager.kt
@@ -60,4 +60,47 @@ class PolicyManager(private val context: Context) {
             Log.e("MDM", "Error configurando timeout: ${e.message}")
         }
     }
+
+    fun disableFactoryReset() {
+        try {
+            dpm.addUserRestriction(componentName, android.os.UserManager.DISALLOW_FACTORY_RESET)
+            Log.d("MDM", "Restablecimiento de fábrica deshabilitado")
+        } catch (e: Exception) {
+            Log.e("MDM", "Error deshabilitando restablecimiento: ${e.message}")
+        }
+    }
+
+    fun lockBrightness() {
+        try {
+            dpm.setSystemSetting(componentName, android.provider.Settings.System.SCREEN_BRIGHTNESS, "255")
+            dpm.setSystemSetting(componentName, android.provider.Settings.System.SCREEN_BRIGHTNESS_MODE,
+                android.provider.Settings.System.SCREEN_BRIGHTNESS_MODE_MANUAL.toString())
+            dpm.addUserRestriction(componentName, android.os.UserManager.DISALLOW_CONFIG_BRIGHTNESS)
+            Log.d("MDM", "Brillo fijado al 100% y bloqueado")
+        } catch (e: Exception) {
+            Log.e("MDM", "Error configurando brillo: ${e.message}")
+        }
+    }
+
+    fun lockGPS() {
+        try {
+            dpm.setSecureSetting(componentName, android.provider.Settings.Secure.LOCATION_MODE,
+                android.provider.Settings.Secure.LOCATION_MODE_HIGH_ACCURACY.toString())
+            dpm.addUserRestriction(componentName, android.os.UserManager.DISALLOW_CONFIG_LOCATION)
+            Log.d("MDM", "GPS forzado y bloqueado")
+        } catch (e: Exception) {
+            Log.e("MDM", "Error configurando GPS: ${e.message}")
+        }
+    }
+
+    fun lockDateTime() {
+        try {
+            dpm.setGlobalSetting(componentName, android.provider.Settings.Global.AUTO_TIME, "1")
+            dpm.setGlobalSetting(componentName, android.provider.Settings.Global.AUTO_TIME_ZONE, "1")
+            dpm.addUserRestriction(componentName, android.os.UserManager.DISALLOW_CONFIG_DATE_TIME)
+            Log.d("MDM", "Fecha y hora configuradas automáticamente y bloqueadas")
+        } catch (e: Exception) {
+            Log.e("MDM", "Error configurando fecha/hora: ${e.message}")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- prevent factory reset and lock brightness, GPS, and date/time via `PolicyManager`
- apply new restrictions from `MDMDeviceAdminReceiver`
- document new device restriction features in README

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848cc2f61f0832f8dd89c6ae4fe5191