### PR TITLE
Add server config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,23 @@ En la carpeta `Servidor` se incluye un pequeño servidor REST escrito en
 Python para propósitos de prueba. Consulta su [README](Servidor/README.md)
 para instrucciones de instalación y ejecución.
 
+## Configuración del servidor
+
+Para que la aplicación se comunique con tu servidor debes modificar la URL
+base que utiliza el cliente HTTP. Edita las siguientes clases y reemplaza
+`https://example.com/` por la dirección donde ejecutes el servidor:
+
+- `app/src/main/java/com/example/mdmjive/services/MDMService.kt`
+- `app/src/main/java/com/example/mdmjive/workers/SyncWorker.kt`
+
+Una vez actualizadas las rutas, compila e instala la aplicación.
+
+## Puesta en marcha
+
+1. Inicia el servidor como se indica en la carpeta `Servidor`.
+2. Instala el APK generado en tu dispositivo Android.
+3. Abre la app y pulsa **"Activar MDM"** para conceder privilegios.
+4. Tras la activación, la app se ocultará y comenzará a sincronizarse con el
+   servidor cada 15 minutos.
+
 

--- a/Servidor/README.md
+++ b/Servidor/README.md
@@ -30,7 +30,12 @@ Ejecuta el servidor con:
 python server.py
 ```
 
-Por defecto escucha en `http://0.0.0.0:5000/`.
+Por defecto escucha en `http://0.0.0.0:5000/`. Puedes cambiar el host o puerto
+mediante las variables de entorno `BIZON_HOST` y `BIZON_PORT`:
+
+```bash
+BIZON_HOST=127.0.0.1 BIZON_PORT=8000 python server.py
+```
 
 ## Endpoints
 

--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify
+import os
 
 app = Flask(__name__)
 
@@ -27,4 +28,6 @@ def update_status():
     return jsonify({'success': True, 'message': 'Estado actualizado'}), 200
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+    host = os.getenv('BIZON_HOST', '0.0.0.0')
+    port = int(os.getenv('BIZON_PORT', '5000'))
+    app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- document how to configure and start the server
- mention where to set the base URL in the Android code
- allow overriding host/port via env vars in the example server

## Testing
- `./gradlew assembleDebug` *(fails: HTTP/1.1 403 Forbidden)*
- `python Servidor/server.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848d1fc8bd4832fb58a2b4b6fcd78e4