### PR TITLE
Enable device details view on server

### DIFF
--- a/Servidor/README.md
+++ b/Servidor/README.md
@@ -54,7 +54,7 @@ Registrar un dispositivo:
 ```bash
 curl -X POST http://localhost:5000/devices/register \
   -H 'Content-Type: application/json' \
-  -d '{"deviceId": "123", "model": "Pixel", "manufacturer": "Google", "osVersion": "13"}'
+  -d '{"deviceId": "123", "model": "Pixel", "manufacturer": "Google", "osVersion": "13", "email": "demo@example.com", "phone": "+123456789", "code": "PX-001", "serial": "ABC123", "activationLocation": "MX"}'
 ```
 
 Actualizar el estado de un dispositivo:
@@ -76,7 +76,8 @@ Ambos devolverán un JSON de la forma:
 
 ## Endpoints disponibles
 
-- `POST /devices/register` – registra un dispositivo; requiere los campos `deviceId`, `model`, `manufacturer` y `osVersion`.
+- `POST /devices/register` – registra un dispositivo. Además de `deviceId`, `model`, `manufacturer` y `osVersion`, puede incluir `email`, `phone`, `code`, `serial` y `activationLocation`.
 - `POST /devices/status` – actualiza el estado del dispositivo; requiere `deviceId`, `status` y `lastUpdate`.
+- `GET /devices/<deviceId>` – muestra la información almacenada del dispositivo, incluyendo la fecha de registro y los datos de contacto.
 
 Este servidor es solo un ejemplo para propósitos de desarrollo y pruebas.

--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -8,6 +8,7 @@ locales.
 
 from flask import Flask, request, jsonify
 import os
+import datetime
 
 app = Flask(__name__)
 
@@ -23,7 +24,8 @@ def register_device():
         return jsonify({'success': False, 'message': 'deviceId requerido'}), 400
     registered_devices[device_id] = {
         'info': data,
-        'status': None
+        'status': None,
+        'added': datetime.datetime.utcnow().isoformat()
     }
     return jsonify({'success': True, 'message': 'Dispositivo registrado'}), 200
 
@@ -36,6 +38,25 @@ def update_status():
         return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
     registered_devices[device_id]['status'] = data
     return jsonify({'success': True, 'message': 'Estado actualizado'}), 200
+
+@app.route('/devices/<device_id>', methods=['GET'])
+def get_device_info(device_id: str):
+    """Devuelve la información completa almacenada de un dispositivo."""
+    device = registered_devices.get(device_id)
+    if not device:
+        return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
+
+    info = device['info']
+    result = {
+        'model': info.get('model'),
+        'code': info.get('code'),
+        'serial': info.get('serial'),
+        'activationLocation': info.get('activationLocation'),
+        'addedDate': device.get('added'),
+        'email': info.get('email'),
+        'phone': info.get('phone')
+    }
+    return jsonify(result), 200
 
 if __name__ == '__main__':
     host = os.getenv('BIZON_HOST', '0.0.0.0')


### PR DESCRIPTION
## Summary
- extend the sample Flask server to store registration date
- add endpoint `/devices/<deviceId>` to view stored device details
- document new optional registration fields and endpoint in server README

## Testing
- `python -m unittest discover -v`
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848e45c71d0832f9e7d297dfb5622b3