### PR TITLE
Add log upload support

### DIFF
--- a/Servidor/README.md
+++ b/Servidor/README.md
@@ -65,6 +65,14 @@ curl -X POST http://localhost:5000/devices/status \
   -d '{"deviceId": "123", "status": "OK", "lastUpdate": "2023-01-01T00:00:00"}'
 ```
 
+Enviar logs de un dispositivo:
+
+```bash
+curl -X POST http://localhost:5000/logs \
+  -H 'Content-Type: application/json' \
+  -d '{"deviceId": "123", "logs": [{"timestamp": 1700000000, "type": "INFO", "message": "Inicio", "severity": "LOW"}]}'
+```
+
 Ambos devolverán un JSON de la forma:
 
 ```json
@@ -79,5 +87,7 @@ Ambos devolverán un JSON de la forma:
 - `POST /devices/register` – registra un dispositivo. Además de `deviceId`, `model`, `manufacturer` y `osVersion`, puede incluir `email`, `phone`, `code`, `serial` y `activationLocation`.
 - `POST /devices/status` – actualiza el estado del dispositivo; requiere `deviceId`, `status` y `lastUpdate`.
 - `GET /devices/<deviceId>` – muestra la información almacenada del dispositivo, incluyendo la fecha de registro y los datos de contacto.
+- `POST /logs` – recibe una lista de logs de un dispositivo.
+- `GET /logs/<deviceId>` – devuelve los logs almacenados para dicho dispositivo.
 
 Este servidor es solo un ejemplo para propósitos de desarrollo y pruebas.

--- a/app/src/main/java/com/example/mdmjive/database/dao/LogDao.kt
+++ b/app/src/main/java/com/example/mdmjive/database/dao/LogDao.kt
@@ -9,6 +9,9 @@ interface LogDao {
     @Query("SELECT * FROM logs ORDER BY timestamp DESC")
     fun getAllLogs(): Flow<List<LogEntry>>
 
+    @Query("SELECT * FROM logs ORDER BY timestamp DESC")
+    suspend fun getAllLogsOnce(): List<LogEntry>
+
     @Query("SELECT * FROM logs WHERE deviceId = :deviceId ORDER BY timestamp DESC")
     fun getLogsByDeviceId(deviceId: String): Flow<List<LogEntry>>
 

--- a/app/src/main/java/com/example/mdmjive/network/ApiService.kt
+++ b/app/src/main/java/com/example/mdmjive/network/ApiService.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import com.example.mdmjive.network.models.ApiResponse
 import com.example.mdmjive.network.models.DeviceInfo
 import com.example.mdmjive.network.models.DeviceStatus
+import com.example.mdmjive.network.models.LogPayload
 
 // Interface para los endpoints de la API
 interface ApiService {
@@ -17,6 +18,9 @@ interface ApiService {
 
     @POST("devices/status")
     suspend fun updateStatus(@Body status: DeviceStatus): Response<ApiResponse>
+
+    @POST("logs")
+    suspend fun uploadLogs(@Body payload: LogPayload): Response<ApiResponse>
 }
 
 

--- a/app/src/main/java/com/example/mdmjive/network/models/LogPayload.kt
+++ b/app/src/main/java/com/example/mdmjive/network/models/LogPayload.kt
@@ -1,0 +1,13 @@
+package com.example.mdmjive.network.models
+
+data class LogEntryPayload(
+    val timestamp: Long,
+    val type: String,
+    val message: String,
+    val severity: String
+)
+
+data class LogPayload(
+    val deviceId: String,
+    val logs: List<LogEntryPayload>
+)


### PR DESCRIPTION
## Summary
- expose `/logs` endpoints on the example server
- document new log API usage
- send logs from the Android client to the server

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848e507b0e4832f9c78c59f6b15d1eb