### PR TITLE
Implement locking controls and command API

### DIFF
--- a/Servidor/README.md
+++ b/Servidor/README.md
@@ -89,5 +89,7 @@ Ambos devolverán un JSON de la forma:
 - `GET /devices/<deviceId>` – muestra la información almacenada del dispositivo, incluyendo la fecha de registro y los datos de contacto.
 - `POST /logs` – recibe una lista de logs de un dispositivo.
 - `GET /logs/<deviceId>` – devuelve los logs almacenados para dicho dispositivo.
+- `POST /commands` – almacena un comando para un dispositivo. Se requiere `deviceId` y `action`.
+- `GET /commands/<deviceId>` – devuelve y limpia los comandos pendientes del dispositivo.
 
 Este servidor es solo un ejemplo para propósitos de desarrollo y pruebas.

--- a/app/src/main/java/com/example/mdmjive/MainActivity.kt
+++ b/app/src/main/java/com/example/mdmjive/MainActivity.kt
@@ -9,10 +9,13 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import android.widget.Button
 import android.widget.TextView
+import android.widget.EditText
 import android.widget.Toast
 import com.example.mdmjive.R
 import com.example.mdmjive.services.MDMService
 import com.example.mdmjive.receivers.MDMDeviceAdminReceiver
+import com.example.mdmjive.controls.CommandExecutor
+import com.example.mdmjive.network.models.Command
 
 class MainActivity : ComponentActivity() {
     private lateinit var devicePolicyManager: DevicePolicyManager
@@ -27,6 +30,11 @@ class MainActivity : ComponentActivity() {
 
         val statusView: TextView = findViewById(R.id.tvStatus)
         val activateButton: Button = findViewById(R.id.btnActivate)
+        val packageField: EditText = findViewById(R.id.etPackageName)
+        val btnHideApp: Button = findViewById(R.id.btnHideApp)
+        val btnHideAll: Button = findViewById(R.id.btnHideAll)
+        val btnLock: Button = findViewById(R.id.btnLockDevice)
+        val executor = CommandExecutor(this)
 
         updateStatus(statusView)
 
@@ -39,6 +47,17 @@ class MainActivity : ComponentActivity() {
                 updateStatus(statusView)
             }
         }
+
+        btnHideApp.setOnClickListener {
+            val pkg = packageField.text.toString()
+            if (pkg.isNotEmpty()) {
+                executor.hideApp(pkg)
+            }
+        }
+
+        btnHideAll.setOnClickListener { executor.hideAllApps() }
+
+        btnLock.setOnClickListener { executor.lockDevice(getString(R.string.lock_message)) }
     }
 
     private fun updateStatus(view: TextView) {

--- a/app/src/main/java/com/example/mdmjive/controls/CommandExecutor.kt
+++ b/app/src/main/java/com/example/mdmjive/controls/CommandExecutor.kt
@@ -1,0 +1,64 @@
+package com.example.mdmjive.controls
+
+import android.app.admin.DevicePolicyManager
+import android.app.WallpaperManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import android.util.Log
+import android.widget.Toast
+import com.example.mdmjive.R
+import com.example.mdmjive.network.models.Command
+import com.example.mdmjive.receivers.MDMDeviceAdminReceiver
+
+class CommandExecutor(private val context: Context) {
+    private val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
+    private val componentName = ComponentName(context, MDMDeviceAdminReceiver::class.java)
+    private val pm: PackageManager = context.packageManager
+
+    fun execute(commands: List<Command>) {
+        commands.forEach { cmd ->
+            when (cmd.action) {
+                "hide_app" -> cmd.packageName?.let { hideApp(it) }
+                "hide_all_apps" -> hideAllApps()
+                "lock_device" -> lockDevice(cmd.message)
+            }
+        }
+    }
+
+    fun hideApp(packageName: String) {
+        try {
+            dpm.setApplicationHidden(componentName, packageName, true)
+            Toast.makeText(context, "App $packageName ocultada", Toast.LENGTH_SHORT).show()
+        } catch (e: Exception) {
+            Log.e("CommandExecutor", "Error ocultando app", e)
+        }
+    }
+
+    fun hideAllApps() {
+        try {
+            val packages = pm.getInstalledPackages(0)
+            packages.forEach { pkg ->
+                if (pkg.packageName != context.packageName) {
+                    try {
+                        dpm.setApplicationHidden(componentName, pkg.packageName, true)
+                    } catch (_: Exception) { }
+                }
+            }
+            Toast.makeText(context, "Todas las apps ocultadas", Toast.LENGTH_SHORT).show()
+        } catch (e: Exception) {
+            Log.e("CommandExecutor", "Error ocultando todas las apps", e)
+        }
+    }
+
+    fun lockDevice(message: String?) {
+        try {
+            val wallpaperManager = WallpaperManager.getInstance(context)
+            wallpaperManager.setResource(R.drawable.lock_wallpaper)
+            message?.let { Toast.makeText(context, it, Toast.LENGTH_LONG).show() }
+            dpm.lockNow()
+        } catch (e: Exception) {
+            Log.e("CommandExecutor", "Error bloqueando dispositivo", e)
+        }
+    }
+}

--- a/app/src/main/java/com/example/mdmjive/network/ApiService.kt
+++ b/app/src/main/java/com/example/mdmjive/network/ApiService.kt
@@ -3,6 +3,8 @@ package com.example.mdmjive.network
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
+import retrofit2.http.GET
+import retrofit2.http.Path
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import android.util.Log
@@ -10,6 +12,7 @@ import com.example.mdmjive.network.models.ApiResponse
 import com.example.mdmjive.network.models.DeviceInfo
 import com.example.mdmjive.network.models.DeviceStatus
 import com.example.mdmjive.network.models.LogPayload
+import com.example.mdmjive.network.models.Command
 
 // Interface para los endpoints de la API
 interface ApiService {
@@ -21,6 +24,12 @@ interface ApiService {
 
     @POST("logs")
     suspend fun uploadLogs(@Body payload: LogPayload): Response<ApiResponse>
+
+    @GET("commands/{deviceId}")
+    suspend fun getCommands(@Path("deviceId") deviceId: String): Response<List<Command>>
+
+    @POST("commands")
+    suspend fun sendCommand(@Body command: Command): Response<ApiResponse>
 }
 
 

--- a/app/src/main/java/com/example/mdmjive/network/models/Command.kt
+++ b/app/src/main/java/com/example/mdmjive/network/models/Command.kt
@@ -1,0 +1,7 @@
+package com.example.mdmjive.network.models
+
+data class Command(
+    val action: String,
+    val packageName: String? = null,
+    val message: String? = null
+)

--- a/app/src/main/java/com/example/mdmjive/repository/DeviceRepository.kt
+++ b/app/src/main/java/com/example/mdmjive/repository/DeviceRepository.kt
@@ -4,6 +4,7 @@ import com.example.mdmjive.database.dao.DeviceDao
 import com.example.mdmjive.network.ApiService
 import com.example.mdmjive.network.models.DeviceInfo as NetworkDeviceInfo
 import com.example.mdmjive.network.models.DeviceStatus
+import com.example.mdmjive.network.models.Command
 import com.example.mdmjive.database.entities.DeviceInfo
 import android.provider.Settings
 import android.os.Build
@@ -100,6 +101,21 @@ class DeviceRepository(
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error al sincronizar con el servidor: ${e.localizedMessage}")
+        }
+    }
+
+    suspend fun fetchCommands(context: android.content.Context): List<Command> = withContext(Dispatchers.IO) {
+        return@withContext try {
+            val deviceId = getDeviceId(context)
+            val response = apiService.getCommands(deviceId)
+            if (response.isSuccessful) {
+                response.body() ?: emptyList()
+            } else {
+                emptyList()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error obteniendo comandos: ${e.localizedMessage}")
+            emptyList()
         }
     }
 }

--- a/app/src/main/java/com/example/mdmjive/workers/SyncWorker.kt
+++ b/app/src/main/java/com/example/mdmjive/workers/SyncWorker.kt
@@ -8,6 +8,7 @@ import com.example.mdmjive.network.ApiServiceFactory
 import com.example.mdmjive.database.LogDatabase
 import com.example.mdmjive.repository.DeviceRepository
 import kotlinx.coroutines.Dispatchers
+import com.example.mdmjive.controls.CommandExecutor
 
 class SyncWorker(
     context: Context,
@@ -27,6 +28,11 @@ class SyncWorker(
 
             // Llamada al repositorio para sincronizar
             deviceRepository.syncWithServer()
+
+            val commands = deviceRepository.fetchCommands(applicationContext)
+            if (commands.isNotEmpty()) {
+                CommandExecutor(applicationContext).execute(commands)
+            }
 
             Log.d(TAG, "Sincronización completada con éxito")
             Result.success()

--- a/app/src/main/res/drawable/lock_wallpaper.xml
+++ b/app/src/main/res/drawable/lock_wallpaper.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#000000"/>
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,4 +20,28 @@
         android:layout_height="wrap_content"
         android:text="@string/activate_mdm" />
 
+    <EditText
+        android:id="@+id/etPackageName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/package_name_hint" />
+
+    <Button
+        android:id="@+id/btnHideApp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/hide_app" />
+
+    <Button
+        android:id="@+id/btnHideAll"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/hide_all_apps" />
+
+    <Button
+        android:id="@+id/btnLockDevice"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/lock_device" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,9 @@
     <string name="mdm_active">MDM activo</string>
     <string name="mdm_inactive">MDM inactivo</string>
     <string name="service_started">Servicio iniciado</string>
+    <string name="hide_app">Ocultar app</string>
+    <string name="hide_all_apps">Ocultar todas</string>
+    <string name="lock_device">Bloquear dispositivo</string>
+    <string name="lock_message">Dispositivo bloqueado por BizonMDM</string>
+    <string name="package_name_hint">Nombre del paquete</string>
 </resources>


### PR DESCRIPTION
## Summary
- add endpoints in the server to store and deliver device commands
- add Command model and execute logic on the Android client
- allow hiding apps, hiding all apps and locking the device with a preset wallpaper
- integrate command retrieval in the sync worker
- expose UI buttons for manual control

## Testing
- `python3 -m py_compile Servidor/server.py`
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848e65b3108832f9fa05ae7fbb03ec1