### PR TITLE
Implement basic persistence and auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 .externalNativeBuild
 .cxx
 local.properties
+__pycache__/
+*.db

--- a/Servidor/README.md
+++ b/Servidor/README.md
@@ -1,11 +1,11 @@
 # Servidor de ejemplo para BizonMDM
 
-Este directorio contiene un peque\u00f1o servidor REST implementado con Flask. Se utiliza para registrar dispositivos, recibir su estado y almacenar logs enviados por la aplicaci\u00f3n BizonMDM. Toda la informaci\u00f3n se guarda en memoria, por lo que solo est\u00e1 pensado para pruebas locales.
+Este directorio contiene un peque\u00f1o servidor REST implementado con Flask. Se utiliza para registrar dispositivos, recibir su estado y almacenar logs enviados por la aplicaci\u00f3n BizonMDM. A partir de esta versi\u00f3n la informaci\u00f3n se almacena en una base de datos SQLite para conservarse entre reinicios.
 
 ## Contenido
 
 - `server.py` - implementaci\u00f3n de los endpoints REST.
-- `requirements.txt` - dependencias de Python (Flask y qrcode).
+- `requirements.txt` - dependencias de Python (Flask, SQLAlchemy y qrcode).
 
 ## Requisitos
 
@@ -32,6 +32,7 @@ Este directorio contiene un peque\u00f1o servidor REST implementado con Flask. S
 Desde esta carpeta ejecuta:
 
 ```bash
+python server.py --init-db      # solo la primera vez
 python server.py
 ```
 
@@ -44,8 +45,13 @@ Ver\u00e1s un mensaje como:
 Puedes detenerlo con `Ctrl+C`. El host y el puerto pueden cambiarse con las variables `BIZON_HOST` y `BIZON_PORT`:
 
 ```bash
-BIZON_HOST=127.0.0.1 BIZON_PORT=8000 python server.py
+BIZON_HOST=127.0.0.1 BIZON_PORT=8000 BIZON_TOKEN=secreto python server.py
 ```
+
+Si defines la variable `BIZON_TOKEN`, todas las peticiones deberán incluir el
+encabezado `Authorization: Bearer <token>`.
+La base de datos se almacena en el archivo indicado por `BIZON_DB` (por defecto
+`bizon.db`).
 
 ### Generar QR de aprovisionamiento
 

--- a/Servidor/models.py
+++ b/Servidor/models.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+from sqlalchemy import create_engine, Column, Integer, String, Text, DateTime, ForeignKey
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
+from sqlalchemy.sql import func
+
+DB_PATH = os.getenv("BIZON_DB", "bizon.db")
+engine = create_engine(f"sqlite:///{DB_PATH}", future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+Base = declarative_base()
+
+class Device(Base):
+    __tablename__ = "devices"
+    id = Column(Integer, primary_key=True)
+    device_id = Column(String, unique=True, nullable=False)
+    info = Column(Text)
+    status = Column(Text)
+    added = Column(DateTime(timezone=True), server_default=func.now())
+
+    logs = relationship("LogEntry", back_populates="device", cascade="all, delete-orphan")
+    commands = relationship("Command", back_populates="device", cascade="all, delete-orphan")
+
+class LogEntry(Base):
+    __tablename__ = "logs"
+    id = Column(Integer, primary_key=True)
+    device_id = Column(Integer, ForeignKey("devices.id"), nullable=False)
+    log = Column(Text)
+
+    device = relationship("Device", back_populates="logs")
+
+class Command(Base):
+    __tablename__ = "commands"
+    id = Column(Integer, primary_key=True)
+    device_id = Column(Integer, ForeignKey("devices.id"), nullable=False)
+    command = Column(Text)
+
+    device = relationship("Device", back_populates="commands")
+
+def init_db() -> None:
+    Base.metadata.create_all(engine)

--- a/Servidor/requirements.txt
+++ b/Servidor/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.3.2
 qrcode
+SQLAlchemy>=2.0

--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -1,27 +1,42 @@
-"""Servidor REST de ejemplo utilizado por la aplicación BizonMDM.
+"""Servidor REST utilizado por la aplicación BizonMDM.
 
-Este script define varios endpoints muy sencillos para registrar un dispositivo,
-actualizar su estado y almacenar logs enviados por la aplicación. Todos los
-datos se guardan en memoria, por lo que el servidor está pensado
-exclusivamente para pruebas locales.
+Ahora almacena la información en una base de datos SQLite en lugar de
+mantener todo en memoria. Permite opcionalmente proteger los endpoints
+mediante un token especificado en ``BIZON_TOKEN``.
 """
 
 from flask import Flask, request, jsonify, send_file
 import os
-import datetime
 import json
 import base64
 import io
 import qrcode
+import logging
+
+from models import Device, LogEntry, Command, SessionLocal, init_db
 
 app = Flask(__name__)
 
-# Diccionario en memoria para almacenar la información de los dispositivos
-registered_devices: dict[str, dict] = {}
-# Diccionario en memoria para almacenar los logs enviados por cada dispositivo
-device_logs: dict[str, list] = {}
-# Cola en memoria de comandos pendientes por dispositivo
-pending_commands: dict[str, list] = {}
+
+# Configuración ---------------------------------------------------------------
+BIZON_TOKEN = os.getenv("BIZON_TOKEN")
+logging.basicConfig(filename="server.log", level=logging.INFO,
+                    format="%(asctime)s %(levelname)s %(message)s")
+
+
+def require_auth(request) -> bool:
+    """Valida el encabezado Authorization si BIZON_TOKEN está definido."""
+    if not BIZON_TOKEN:
+        return True
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer ") and auth.split(" ", 1)[1] == BIZON_TOKEN:
+        return True
+    return False
+
+
+def get_session():
+    """Obtiene una nueva sesión de base de datos."""
+    return SessionLocal()
 
 
 def _generate_provisioning_string(server_url: str, device_id: str, skip_encryption: bool = True) -> str:
@@ -53,44 +68,59 @@ def get_provisioning_qr(device_id: str):
 @app.route('/devices/register', methods=['POST'])
 def register_device():
     """Registra un dispositivo a partir de un JSON enviado por la app."""
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
     data = request.get_json() or {}
     device_id = data.get('deviceId')
     if not device_id:
         return jsonify({'success': False, 'message': 'deviceId requerido'}), 400
-    registered_devices[device_id] = {
-        'info': data,
-        'status': None,
-        'added': datetime.datetime.utcnow().isoformat()
-    }
+    with get_session() as db:
+        device = db.query(Device).filter_by(device_id=device_id).first()
+        if not device:
+            device = Device(device_id=device_id, info=json.dumps(data))
+            db.add(device)
+        else:
+            device.info = json.dumps(data)
+        db.commit()
+    logging.info('registro dispositivo %s', device_id)
     return jsonify({'success': True, 'message': 'Dispositivo registrado'}), 200
 
 @app.route('/devices/status', methods=['POST'])
 def update_status():
     """Actualiza el estado del dispositivo previamente registrado."""
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
     data = request.get_json() or {}
     device_id = data.get('deviceId')
-    if not device_id or device_id not in registered_devices:
-        return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
-    registered_devices[device_id]['status'] = data
+    if not device_id:
+        return jsonify({'success': False, 'message': 'deviceId requerido'}), 400
+    with get_session() as db:
+        device = db.query(Device).filter_by(device_id=device_id).first()
+        if not device:
+            return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
+        device.status = json.dumps(data)
+        db.commit()
     return jsonify({'success': True, 'message': 'Estado actualizado'}), 200
 
 @app.route('/devices/<device_id>', methods=['GET'])
 def get_device_info(device_id: str):
     """Devuelve la información completa almacenada de un dispositivo."""
-    device = registered_devices.get(device_id)
-    if not device:
-        return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
-
-    info = device['info']
-    result = {
-        'model': info.get('model'),
-        'code': info.get('code'),
-        'serial': info.get('serial'),
-        'activationLocation': info.get('activationLocation'),
-        'addedDate': device.get('added'),
-        'email': info.get('email'),
-        'phone': info.get('phone')
-    }
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+    with get_session() as db:
+        device = db.query(Device).filter_by(device_id=device_id).first()
+        if not device:
+            return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
+        info = json.loads(device.info or '{}')
+        result = {
+            'model': info.get('model'),
+            'code': info.get('code'),
+            'serial': info.get('serial'),
+            'activationLocation': info.get('activationLocation'),
+            'addedDate': device.added.isoformat() if device.added else None,
+            'email': info.get('email'),
+            'phone': info.get('phone')
+        }
     return jsonify(result), 200
 
 # --- Endpoints para manejo de logs ---
@@ -98,46 +128,83 @@ def get_device_info(device_id: str):
 @app.route('/logs', methods=['POST'])
 def upload_logs():
     """Recibe una lista de logs enviados por un dispositivo."""
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
     data = request.get_json() or {}
     device_id = data.get('deviceId')
     logs = data.get('logs', [])
-    if not device_id or device_id not in registered_devices:
-        return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
+    if not device_id:
+        return jsonify({'success': False, 'message': 'deviceId requerido'}), 400
 
-    stored = device_logs.setdefault(device_id, [])
-    if isinstance(logs, list):
-        stored.extend(logs)
+    with get_session() as db:
+        device = db.query(Device).filter_by(device_id=device_id).first()
+        if not device:
+            return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
+        if isinstance(logs, list):
+            for entry in logs:
+                db.add(LogEntry(device_id=device.id, log=json.dumps(entry)))
+            db.commit()
     return jsonify({'success': True, 'message': 'Logs recibidos', 'count': len(logs)}), 200
 
 
 @app.route('/logs/<device_id>', methods=['GET'])
 def get_logs(device_id: str):
     """Devuelve los logs almacenados de un dispositivo."""
-    if device_id not in registered_devices:
-        return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
-    logs = device_logs.get(device_id, [])
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+    with get_session() as db:
+        device = db.query(Device).filter_by(device_id=device_id).first()
+        if not device:
+            return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
+        logs = [json.loads(l.log) for l in device.logs]
     return jsonify({'logs': logs}), 200
 
 # --- Endpoints de control de dispositivos ---
 
 @app.route('/commands', methods=['POST'])
 def add_command():
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
     data = request.get_json() or {}
     device_id = data.get('deviceId')
     action = data.get('action')
     if not device_id or not action:
         return jsonify({'success': False, 'message': 'deviceId y action requeridos'}), 400
-    pending_commands.setdefault(device_id, []).append(data)
+    with get_session() as db:
+        device = db.query(Device).filter_by(device_id=device_id).first()
+        if not device:
+            return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
+        db.add(Command(device_id=device.id, command=json.dumps(data)))
+        db.commit()
     return jsonify({'success': True, 'message': 'Comando almacenado'}), 200
 
 
 @app.route('/commands/<device_id>', methods=['GET'])
 def get_commands(device_id: str):
-    cmds = pending_commands.get(device_id, [])
-    pending_commands[device_id] = []
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+    with get_session() as db:
+        device = db.query(Device).filter_by(device_id=device_id).first()
+        if not device:
+            return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
+        cmds = [json.loads(c.command) for c in device.commands]
+        for c in device.commands:
+            db.delete(c)
+        db.commit()
     return jsonify(cmds), 200
 
 if __name__ == '__main__':
-    host = os.getenv('BIZON_HOST', '0.0.0.0')
-    port = int(os.getenv('BIZON_PORT', '5000'))
-    app.run(host=host, port=port)
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Servidor BizonMDM")
+    parser.add_argument('--init-db', action='store_true', help='Inicializar base de datos y salir')
+    args = parser.parse_args()
+
+    if args.init_db:
+        init_db()
+        print('Base de datos inicializada')
+    else:
+        host = os.getenv('BIZON_HOST', '0.0.0.0')
+        port = int(os.getenv('BIZON_PORT', '5000'))
+        init_db()
+        app.run(host=host, port=port)

--- a/Servidor/tests/test_server.py
+++ b/Servidor/tests/test_server.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+import unittest
+import sys
+
+os.environ['BIZON_TOKEN'] = 'testtoken'
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from server import app, init_db
+
+class ServerTestCase(unittest.TestCase):
+    def setUp(self):
+        self.db_fd, self.db_path = tempfile.mkstemp()
+        os.environ['BIZON_DB'] = self.db_path
+        init_db()
+        self.client = app.test_client()
+        self.token = 'testtoken'
+        os.environ['BIZON_TOKEN'] = self.token
+
+    def tearDown(self):
+        os.close(self.db_fd)
+        os.unlink(self.db_path)
+
+    def auth_header(self):
+        return {'Authorization': f'Bearer {self.token}'}
+
+    def test_register_device(self):
+        data = {'deviceId': 'd1', 'model': 'Pixel'}
+        resp = self.client.post('/devices/register', json=data, headers=self.auth_header())
+        self.assertEqual(resp.status_code, 200)
+        resp = self.client.get('/devices/d1', headers=self.auth_header())
+        self.assertEqual(resp.status_code, 200)
+        info = resp.get_json()
+        self.assertEqual(info['model'], 'Pixel')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and initialization logic
- integrate SQLite persistence and token-based auth into server
- update requirements and docs
- create minimal unit test
- ignore Python artifacts

## Testing
- `python -m py_compile Servidor/server.py Servidor/models.py Servidor/tests/test_server.py`
- `python -m unittest discover -s Servidor/tests` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848eed4c5f0832fb971ca31579e1855