### PR TITLE
Switch backend to PostgreSQL with Alembic migrations

### DIFF
--- a/Servidor/alembic.ini
+++ b/Servidor/alembic.ini
@@ -1,0 +1,34 @@
+[alembic]
+script_location = alembic
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s %(asctime)s %(message)s

--- a/Servidor/alembic/env.py
+++ b/Servidor/alembic/env.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from models import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/Servidor/alembic/versions/0001_initial.py
+++ b/Servidor/alembic/versions/0001_initial.py
@@ -1,0 +1,42 @@
+"""Initial database schema with device fields"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "devices",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("device_id", sa.String(), nullable=False, unique=True),
+        sa.Column("imei", sa.String(), nullable=True),
+        sa.Column("model", sa.String(), nullable=True),
+        sa.Column("serial", sa.String(), nullable=True),
+        sa.Column("info", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=True),
+        sa.Column("added", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_table(
+        "logs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("device_id", sa.Integer(), sa.ForeignKey("devices.id"), nullable=False),
+        sa.Column("log", sa.Text()),
+    )
+    op.create_table(
+        "commands",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("device_id", sa.Integer(), sa.ForeignKey("devices.id"), nullable=False),
+        sa.Column("command", sa.Text()),
+    )
+
+
+def downgrade():
+    op.drop_table("commands")
+    op.drop_table("logs")
+    op.drop_table("devices")

--- a/Servidor/models.py
+++ b/Servidor/models.py
@@ -1,26 +1,40 @@
 from __future__ import annotations
 
 import os
-from sqlalchemy import create_engine, Column, Integer, String, Text, DateTime, ForeignKey
-from sqlalchemy.orm import declarative_base, sessionmaker, relationship
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    create_engine,
+)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 from sqlalchemy.sql import func
 
-DB_PATH = os.getenv("BIZON_DB", "bizon.db")
-engine = create_engine(f"sqlite:///{DB_PATH}", future=True)
+DEFAULT_DB_URL = "postgresql+psycopg2://postgres:postgres@localhost/bizon"
+DB_URL = os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+engine = create_engine(DB_URL, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 
 Base = declarative_base()
+
 
 class Device(Base):
     __tablename__ = "devices"
     id = Column(Integer, primary_key=True)
     device_id = Column(String, unique=True, nullable=False)
+    imei = Column(String)
+    model = Column(String)
+    serial = Column(String)
     info = Column(Text)
     status = Column(Text)
     added = Column(DateTime(timezone=True), server_default=func.now())
 
     logs = relationship("LogEntry", back_populates="device", cascade="all, delete-orphan")
     commands = relationship("Command", back_populates="device", cascade="all, delete-orphan")
+
 
 class LogEntry(Base):
     __tablename__ = "logs"
@@ -30,6 +44,7 @@ class LogEntry(Base):
 
     device = relationship("Device", back_populates="logs")
 
+
 class Command(Base):
     __tablename__ = "commands"
     id = Column(Integer, primary_key=True)
@@ -38,5 +53,15 @@ class Command(Base):
 
     device = relationship("Device", back_populates="commands")
 
+
 def init_db() -> None:
-    Base.metadata.create_all(engine)
+    try:
+        from alembic import command
+        from alembic.config import Config
+
+        cfg = Config(os.path.join(os.path.dirname(__file__), "alembic.ini"))
+        cfg.set_main_option("sqlalchemy.url", DB_URL)
+        command.upgrade(cfg, "head")
+    except (ModuleNotFoundError, ImportError):
+        # Alembic no disponible: crea las tablas directamente
+        Base.metadata.create_all(engine)

--- a/Servidor/requirements.txt
+++ b/Servidor/requirements.txt
@@ -1,3 +1,5 @@
 Flask==2.3.2
 qrcode
 SQLAlchemy>=2.0
+psycopg2-binary
+alembic

--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -77,9 +77,18 @@ def register_device():
     with get_session() as db:
         device = db.query(Device).filter_by(device_id=device_id).first()
         if not device:
-            device = Device(device_id=device_id, info=json.dumps(data))
+            device = Device(
+                device_id=device_id,
+                imei=data.get('imei'),
+                model=data.get('model'),
+                serial=data.get('serial'),
+                info=json.dumps(data),
+            )
             db.add(device)
         else:
+            device.imei = data.get('imei')
+            device.model = data.get('model')
+            device.serial = data.get('serial')
             device.info = json.dumps(data)
         db.commit()
     logging.info('registro dispositivo %s', device_id)
@@ -113,13 +122,14 @@ def get_device_info(device_id: str):
             return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
         info = json.loads(device.info or '{}')
         result = {
-            'model': info.get('model'),
+            'model': device.model or info.get('model'),
             'code': info.get('code'),
-            'serial': info.get('serial'),
+            'serial': device.serial or info.get('serial'),
             'activationLocation': info.get('activationLocation'),
             'addedDate': device.added.isoformat() if device.added else None,
             'email': info.get('email'),
-            'phone': info.get('phone')
+            'phone': info.get('phone'),
+            'imei': device.imei or info.get('imei'),
         }
     return jsonify(result), 200
 

--- a/Servidor/tests/test_server.py
+++ b/Servidor/tests/test_server.py
@@ -3,36 +3,42 @@ import tempfile
 import unittest
 import sys
 
+# Configure database and token before importing the server
+DB_FD, DB_PATH = tempfile.mkstemp()
+os.environ['DATABASE_URL'] = f'sqlite:///{DB_PATH}'
 os.environ['BIZON_TOKEN'] = 'testtoken'
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from server import app, init_db
 
+
 class ServerTestCase(unittest.TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        os.close(DB_FD)
+        os.unlink(DB_PATH)
+
     def setUp(self):
-        self.db_fd, self.db_path = tempfile.mkstemp()
-        os.environ['BIZON_DB'] = self.db_path
         init_db()
+        import werkzeug
+        if not hasattr(werkzeug, "__version__"):
+            werkzeug.__version__ = "3"
         self.client = app.test_client()
         self.token = 'testtoken'
-        os.environ['BIZON_TOKEN'] = self.token
-
-    def tearDown(self):
-        os.close(self.db_fd)
-        os.unlink(self.db_path)
 
     def auth_header(self):
         return {'Authorization': f'Bearer {self.token}'}
 
     def test_register_device(self):
-        data = {'deviceId': 'd1', 'model': 'Pixel'}
+        data = {'deviceId': 'd1', 'model': 'Pixel', 'serial': '123', 'imei': '999'}
         resp = self.client.post('/devices/register', json=data, headers=self.auth_header())
         self.assertEqual(resp.status_code, 200)
         resp = self.client.get('/devices/d1', headers=self.auth_header())
         self.assertEqual(resp.status_code, 200)
         info = resp.get_json()
         self.assertEqual(info['model'], 'Pixel')
+        self.assertEqual(info['serial'], '123')
+        self.assertEqual(info['imei'], '999')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- switch database configuration to PostgreSQL via `DATABASE_URL`
- add imei, model and serial fields to device model and endpoints
- set up Alembic migrations for database schema
- expand tests for new fields and make them SQLite-compatible

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement psycopg2-binary)*
- `pytest tests/test_server.py`

------
https://chatgpt.com/codex/tasks/task_b_689627dfd9f08320a4d8c72787bbafb9