### PR TITLE
Implementar autenticación JWT y soporte SSL

### DIFF
--- a/Servidor/README.md
+++ b/Servidor/README.md
@@ -45,11 +45,13 @@ Ver\u00e1s un mensaje como:
 Puedes detenerlo con `Ctrl+C`. El host y el puerto pueden cambiarse con las variables `BIZON_HOST` y `BIZON_PORT`:
 
 ```bash
-BIZON_HOST=127.0.0.1 BIZON_PORT=8000 BIZON_TOKEN=secreto python server.py
+BIZON_HOST=127.0.0.1 BIZON_PORT=8000 JWT_SECRET=secreto python server.py
 ```
 
-Si defines la variable `BIZON_TOKEN`, todas las peticiones deberán incluir el
-encabezado `Authorization: Bearer <token>`.
+Si defines la variable `JWT_SECRET`, todas las peticiones deberán incluir un
+token JWT válido en el encabezado `Authorization: Bearer <token>`.
+Para habilitar HTTPS establece `SSL_CERT` y `SSL_KEY` apuntando al certificado
+y a la llave privada respectivamente.
 La base de datos se almacena en el archivo indicado por `BIZON_DB` (por defecto
 `bizon.db`).
 

--- a/Servidor/models.py
+++ b/Servidor/models.py
@@ -59,8 +59,10 @@ def init_db() -> None:
         from alembic import command
         from alembic.config import Config
 
-        cfg = Config(os.path.join(os.path.dirname(__file__), "alembic.ini"))
+        base_dir = os.path.dirname(__file__)
+        cfg = Config(os.path.join(base_dir, "alembic.ini"))
         cfg.set_main_option("sqlalchemy.url", DB_URL)
+        cfg.set_main_option("script_location", os.path.join(base_dir, "alembic"))
         command.upgrade(cfg, "head")
     except (ModuleNotFoundError, ImportError):
         # Alembic no disponible: crea las tablas directamente

--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -2,7 +2,7 @@
 
 Ahora almacena la información en una base de datos SQLite en lugar de
 mantener todo en memoria. Permite opcionalmente proteger los endpoints
-mediante un token especificado en ``BIZON_TOKEN``.
+mediante un token firmado mediante JWT.
 """
 
 from flask import Flask, request, jsonify, send_file
@@ -12,6 +12,8 @@ import base64
 import io
 import qrcode
 import logging
+import hmac
+import hashlib
 
 from models import Device, LogEntry, Command, SessionLocal, init_db
 
@@ -19,19 +21,54 @@ app = Flask(__name__)
 
 
 # Configuración ---------------------------------------------------------------
-BIZON_TOKEN = os.getenv("BIZON_TOKEN")
+JWT_SECRET = os.getenv("JWT_SECRET")
 logging.basicConfig(filename="server.log", level=logging.INFO,
                     format="%(asctime)s %(levelname)s %(message)s")
 
 
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("utf-8")
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def encode_jwt(payload: dict, secret: str) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    signature = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    signature_b64 = _b64url_encode(signature)
+    return f"{header_b64}.{payload_b64}.{signature_b64}"
+
+
+def decode_jwt(token: str, secret: str) -> dict:
+    header_b64, payload_b64, signature_b64 = token.split(".")
+    signing_input = f"{header_b64}.{payload_b64}".encode()
+    signature = _b64url_decode(signature_b64)
+    expected = hmac.new(secret.encode(), signing_input, hashlib.sha256).digest()
+    if not hmac.compare_digest(signature, expected):
+        raise ValueError("Invalid signature")
+    payload = json.loads(_b64url_decode(payload_b64))
+    return payload
+
+
 def require_auth(request) -> bool:
-    """Valida el encabezado Authorization si BIZON_TOKEN está definido."""
-    if not BIZON_TOKEN:
+    """Valida el encabezado Authorization mediante JWT si está configurado."""
+    if not JWT_SECRET:
         return True
     auth = request.headers.get("Authorization", "")
-    if auth.startswith("Bearer ") and auth.split(" ", 1)[1] == BIZON_TOKEN:
+    if not auth.startswith("Bearer "):
+        return False
+    token = auth.split(" ", 1)[1]
+    try:
+        decode_jwt(token, JWT_SECRET)
         return True
-    return False
+    except Exception:
+        return False
 
 
 def get_session():
@@ -216,5 +253,8 @@ if __name__ == '__main__':
     else:
         host = os.getenv('BIZON_HOST', '0.0.0.0')
         port = int(os.getenv('BIZON_PORT', '5000'))
+        ssl_cert = os.getenv('SSL_CERT')
+        ssl_key = os.getenv('SSL_KEY')
+        ssl_context = (ssl_cert, ssl_key) if ssl_cert and ssl_key else None
         init_db()
-        app.run(host=host, port=port)
+        app.run(host=host, port=port, ssl_context=ssl_context)

--- a/Servidor/tests/test_server.py
+++ b/Servidor/tests/test_server.py
@@ -6,10 +6,10 @@ import sys
 # Configure database and token before importing the server
 DB_FD, DB_PATH = tempfile.mkstemp()
 os.environ['DATABASE_URL'] = f'sqlite:///{DB_PATH}'
-os.environ['BIZON_TOKEN'] = 'testtoken'
+os.environ['JWT_SECRET'] = 'testsecret'
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from server import app, init_db
+from server import app, init_db, encode_jwt
 
 
 class ServerTestCase(unittest.TestCase):
@@ -24,7 +24,7 @@ class ServerTestCase(unittest.TestCase):
         if not hasattr(werkzeug, "__version__"):
             werkzeug.__version__ = "3"
         self.client = app.test_client()
-        self.token = 'testtoken'
+        self.token = encode_jwt({'sub': 'tester'}, os.environ['JWT_SECRET'])
 
     def auth_header(self):
         return {'Authorization': f'Bearer {self.token}'}


### PR DESCRIPTION
## Resumen
- Añadir implementación ligera de JWT para proteger los endpoints del servidor.
- Permitir ejecutar el servidor con HTTPS mediante variables de entorno `SSL_CERT` y `SSL_KEY`.
- Actualizar documentación y pruebas para reflejar la nueva autenticación.

## Pruebas
- `pytest Servidor/tests/test_server.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68962a648f688320b99f6b4786588f62