### PR TITLE
feat(server): send push commands via fcm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ La app permite registrar un dispositivo, sincronizar periódicamente su informac
 - **Controles de seguridad** que aplican políticas sobre el dispositivo.
 - **Modo sigiloso** que oculta la app y evita su desinstalación tras conceder privilegios de administrador.
 - **Restricciones** que deshabilitan el formateo, fijan el brillo al 100 %, fuerzan el GPS activo y evitan cambios de fecha u hora.
+- **Notificaciones push** mediante Firebase Cloud Messaging para recibir comandos al instante.
 
 ## Estructura del repositorio
 

--- a/Servidor/README.md
+++ b/Servidor/README.md
@@ -55,6 +55,13 @@ y a la llave privada respectivamente.
 La base de datos se almacena en el archivo indicado por `BIZON_DB` (por defecto
 `bizon.db`).
 
+### Notificaciones push
+
+Si estableces la variable de entorno `FCM_SERVER_KEY` el servidor enviará
+una notificación de Firebase Cloud Messaging cada vez que se encole un
+comando para un dispositivo. La aplicación debe incluir su `fcmToken` al
+registrarse o actualizar su estado para que el servidor pueda utilizarlo.
+
 ### Generar QR de aprovisionamiento
 
 Para facilitar la instalación del MDM sin intervención manual puedes

--- a/Servidor/alembic/versions/0001_initial.py
+++ b/Servidor/alembic/versions/0001_initial.py
@@ -20,6 +20,7 @@ def upgrade():
         sa.Column("serial", sa.String(), nullable=True),
         sa.Column("info", sa.Text(), nullable=True),
         sa.Column("status", sa.Text(), nullable=True),
+        sa.Column("fcm_token", sa.String(), nullable=True),
         sa.Column("added", sa.DateTime(timezone=True), server_default=sa.func.now()),
     )
     op.create_table(

--- a/Servidor/models.py
+++ b/Servidor/models.py
@@ -30,6 +30,7 @@ class Device(Base):
     serial = Column(String)
     info = Column(Text)
     status = Column(Text)
+    fcm_token = Column(String)
     added = Column(DateTime(timezone=True), server_default=func.now())
 
     logs = relationship("LogEntry", back_populates="device", cascade="all, delete-orphan")

--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -14,6 +14,7 @@ import qrcode
 import logging
 import hmac
 import hashlib
+import urllib.request
 
 from models import Device, LogEntry, Command, SessionLocal, init_db
 
@@ -22,6 +23,8 @@ app = Flask(__name__)
 
 # Configuración ---------------------------------------------------------------
 JWT_SECRET = os.getenv("JWT_SECRET")
+FCM_SERVER_KEY = os.getenv("FCM_SERVER_KEY")
+FCM_URL = "https://fcm.googleapis.com/fcm/send"
 logging.basicConfig(filename="server.log", level=logging.INFO,
                     format="%(asctime)s %(levelname)s %(message)s")
 
@@ -120,6 +123,7 @@ def register_device():
                 model=data.get('model'),
                 serial=data.get('serial'),
                 info=json.dumps(data),
+                fcm_token=data.get('fcmToken'),
             )
             db.add(device)
         else:
@@ -127,6 +131,8 @@ def register_device():
             device.model = data.get('model')
             device.serial = data.get('serial')
             device.info = json.dumps(data)
+            if data.get('fcmToken'):
+                device.fcm_token = data.get('fcmToken')
         db.commit()
     logging.info('registro dispositivo %s', device_id)
     return jsonify({'success': True, 'message': 'Dispositivo registrado'}), 200
@@ -145,6 +151,8 @@ def update_status():
         if not device:
             return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
         device.status = json.dumps(data)
+        if data.get('fcmToken'):
+            device.fcm_token = data.get('fcmToken')
         db.commit()
     return jsonify({'success': True, 'message': 'Estado actualizado'}), 200
 
@@ -220,7 +228,26 @@ def _queue_command(device_id: str, action: str, extra: dict | None = None):
             payload.update(extra)
         db.add(Command(device_id=device.id, command=json.dumps(payload)))
         db.commit()
+        token = device.fcm_token
+    _send_fcm_message(token, payload)
     return True
+
+
+def _send_fcm_message(token: str | None, payload: dict) -> None:
+    if not token or not FCM_SERVER_KEY:
+        return
+    headers = {
+        "Authorization": f"key={FCM_SERVER_KEY}",
+        "Content-Type": "application/json",
+    }
+    body = {"to": token, "data": payload}
+    try:
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(FCM_URL, data=data, headers=headers)
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+    except Exception as exc:
+        logging.warning("Error enviando FCM: %s", exc)
 
 
 @app.route('/api/device/wipe', methods=['POST'])

--- a/Servidor/tests/test_server.py
+++ b/Servidor/tests/test_server.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import unittest
 import sys
+from unittest import mock
 
 # Configure database and token before importing the server
 DB_FD, DB_PATH = tempfile.mkstemp()
@@ -80,6 +81,28 @@ class ServerTestCase(unittest.TestCase):
         cmds = resp.get_json()
         self.assertEqual(cmds[0]['action'], 'app_uninstall')
         self.assertEqual(cmds[0]['package'], 'com.example.app')
+
+    @mock.patch('server._send_fcm_message')
+    def test_fcm_notification_sent(self, mock_send):
+        os.environ['FCM_SERVER_KEY'] = 'dummy'
+        try:
+            self.client.post(
+                '/devices/register',
+                json={'deviceId': 'd1', 'fcmToken': 'tok'},
+                headers=self.auth_header(),
+            )
+            resp = self.client.post(
+                '/api/device/reboot',
+                json={'deviceId': 'd1'},
+                headers=self.auth_header(),
+            )
+            self.assertEqual(resp.status_code, 200)
+            mock_send.assert_called_once()
+            token, payload = mock_send.call_args.args
+            self.assertEqual(token, 'tok')
+            self.assertEqual(payload['action'], 'device_reboot')
+        finally:
+            del os.environ['FCM_SERVER_KEY']
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add optional FCM token field to device model and migration
- trigger Firebase push when queuing device commands
- document new FCM setup and add regression test

## Testing
- `cd Servidor && pip install -r requirements.txt >/tmp/pip.log && tail -n 20 /tmp/pip.log` *(failed: Could not find a version that satisfies the requirement requests)*
- `cd Servidor && pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68962cb707b48320a5b6d6c2bb1b0911