### PR TITLE
Add admin web frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@
 local.properties
 __pycache__/
 *.db
+
+# Frontend
+node_modules/
+dist/
+

--- a/admin-frontend/app.jsx
+++ b/admin-frontend/app.jsx
@@ -1,0 +1,117 @@
+const { useState, useEffect } = React;
+
+function Dashboard() {
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <p>Resumen visual de la flota de dispositivos.</p>
+    </div>
+  );
+}
+
+function DeviceTable({ onSelect }) {
+  const devices = [
+    { id: 1, imei: '123456789012345', model: 'Pixel 5', serial: 'ABC123', status: 'Activo' },
+    { id: 2, imei: '987654321098765', model: 'Galaxy S21', serial: 'XYZ987', status: 'Inactivo' }
+  ];
+  return (
+    <div>
+      <h2>Dispositivos</h2>
+      <input placeholder="Buscar..." />
+      <table>
+        <thead>
+          <tr>
+            <th>IMEI</th>
+            <th>Modelo</th>
+            <th>Serial</th>
+            <th>Estado</th>
+          </tr>
+        </thead>
+        <tbody>
+          {devices.map(d => (
+            <tr key={d.id} onClick={() => onSelect(d.id)} style={{ cursor: 'pointer' }}>
+              <td>{d.imei}</td>
+              <td>{d.model}</td>
+              <td>{d.serial}</td>
+              <td>{d.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function DeviceDetails({ id, onBack }) {
+  return (
+    <div>
+      <h2>Dispositivo {id}</h2>
+      <p>Información detallada del dispositivo.</p>
+      <div className="actions">
+        <button>Borrar Datos</button>
+        <button>Reiniciar</button>
+      </div>
+      <h3>Historial de Logs</h3>
+      <ul>
+        <li>Log 1...</li>
+        <li>Log 2...</li>
+      </ul>
+      <button onClick={onBack}>Volver</button>
+    </div>
+  );
+}
+
+function PolicyEditor() {
+  const [name, setName] = useState('');
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    alert(`Política "${name}" creada (demo)`);
+    setName('');
+  };
+  return (
+    <div>
+      <h2>Editor de Políticas</h2>
+      <form onSubmit={handleSubmit}>
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="Nombre" />
+        <button type="submit">Guardar</button>
+      </form>
+    </div>
+  );
+}
+
+function App() {
+  const [route, setRoute] = useState(window.location.hash || '#/dashboard');
+
+  useEffect(() => {
+    const onHashChange = () => setRoute(window.location.hash || '#/dashboard');
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  let page;
+  if (route === '#/dashboard') page = <Dashboard />;
+  else if (route === '#/devices') page = <DeviceTable onSelect={(id) => window.location.hash = `#/devices/${id}`} />;
+  else if (route.startsWith('#/devices/')) {
+    const id = route.split('/')[2];
+    page = <DeviceDetails id={id} onBack={() => window.location.hash = '#/devices'} />;
+  } else if (route === '#/policies') page = <PolicyEditor />;
+  else page = <Dashboard />;
+
+  return (
+    <div>
+      <header>
+        <h1>Bizon MDM Admin</h1>
+        <nav>
+          <a href="#/dashboard">Dashboard</a>
+          <a href="#/devices">Dispositivos</a>
+          <a href="#/policies">Políticas</a>
+        </nav>
+      </header>
+      <main style={{ padding: '1rem' }}>
+        {page}
+      </main>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/admin-frontend/index.html
+++ b/admin-frontend/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bizon MDM Admin</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+    header { background: #222; color: #fff; padding: 1rem; }
+    nav a { margin-right: 1rem; color: #61dafb; text-decoration: none; }
+    table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+    th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }
+    th { background: #f0f0f0; }
+    .actions button { margin-right: 0.5rem; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "admin-frontend",
+  "version": "1.0.0",
+  "description": "Aplicación web de administración para Bizon MDM",
+  "scripts": {
+    "test": "echo 'No tests'"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
## Summary
- add standalone admin frontend using React CDN with dashboard, device list, device details and policy editor
- ignore frontend build artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68963056f61c8320b66234c0eb62c8ca