### PR TITLE
Integrate admin panel with backend API

### DIFF
--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -156,6 +156,26 @@ def update_status():
         db.commit()
     return jsonify({'success': True, 'message': 'Estado actualizado'}), 200
 
+
+@app.route('/devices', methods=['GET'])
+def list_devices():
+    """Devuelve la lista de dispositivos registrados."""
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+    with get_session() as db:
+        devices = db.query(Device).all()
+        result = []
+        for d in devices:
+            status = json.loads(d.status or '{}')
+            result.append({
+                'deviceId': d.device_id,
+                'imei': d.imei,
+                'model': d.model,
+                'serial': d.serial,
+                'status': status,
+            })
+    return jsonify(result), 200
+
 @app.route('/devices/<device_id>', methods=['GET'])
 def get_device_info(device_id: str):
     """Devuelve la información completa almacenada de un dispositivo."""
@@ -166,6 +186,7 @@ def get_device_info(device_id: str):
         if not device:
             return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
         info = json.loads(device.info or '{}')
+        status = json.loads(device.status or '{}')
         result = {
             'model': device.model or info.get('model'),
             'code': info.get('code'),
@@ -175,6 +196,7 @@ def get_device_info(device_id: str):
             'email': info.get('email'),
             'phone': info.get('phone'),
             'imei': device.imei or info.get('imei'),
+            'status': status,
         }
     return jsonify(result), 200
 

--- a/admin-frontend/app.jsx
+++ b/admin-frontend/app.jsx
@@ -1,23 +1,69 @@
 const { useState, useEffect } = React;
 
+const API_BASE = '';
+
+async function apiFetch(path, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = options.headers ? { ...options.headers } : {};
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  if (options.body && !headers['Content-Type']) {
+    headers['Content-Type'] = 'application/json';
+  }
+  const res = await fetch(API_BASE + path, { ...options, headers });
+  if (!res.ok) throw new Error('API error');
+  return res.json();
+}
+
 function Dashboard() {
+  const [devices, setDevices] = useState([]);
+  useEffect(() => {
+    apiFetch('/devices').then(setDevices).catch(console.error);
+  }, []);
+  const total = devices.length;
+  const modelCounts = devices.reduce((acc, d) => {
+    const m = d.model || 'Desconocido';
+    acc[m] = (acc[m] || 0) + 1;
+    return acc;
+  }, {});
+  const alerts = [];
+  devices.forEach(d => {
+    const s = d.status || {};
+    if (s.battery && s.battery < 20) alerts.push(`Batería baja en ${d.deviceId} (${s.battery}%)`);
+    if (s.rootAttempt) alerts.push(`Intento de root en ${d.deviceId}`);
+  });
   return (
     <div>
       <h2>Dashboard</h2>
-      <p>Resumen visual de la flota de dispositivos.</p>
+      <p>Dispositivos registrados: {total}</p>
+      <h3>Distribución por modelo</h3>
+      <ul>
+        {Object.entries(modelCounts).map(([m, c]) => (
+          <li key={m}>{m}: {c}</li>
+        ))}
+      </ul>
+      <h3>Alertas</h3>
+      <ul>
+        {alerts.length ? alerts.map((a, i) => <li key={i}>{a}</li>) : <li>Sin alertas</li>}
+      </ul>
     </div>
   );
 }
 
 function DeviceTable({ onSelect }) {
-  const devices = [
-    { id: 1, imei: '123456789012345', model: 'Pixel 5', serial: 'ABC123', status: 'Activo' },
-    { id: 2, imei: '987654321098765', model: 'Galaxy S21', serial: 'XYZ987', status: 'Inactivo' }
-  ];
+  const [devices, setDevices] = useState([]);
+  const [search, setSearch] = useState('');
+  useEffect(() => {
+    apiFetch('/devices').then(setDevices).catch(console.error);
+  }, []);
+  const filtered = devices.filter(d =>
+    [d.deviceId, d.imei, d.model, d.serial]
+      .filter(Boolean)
+      .some(v => v.toLowerCase().includes(search.toLowerCase()))
+  );
   return (
     <div>
       <h2>Dispositivos</h2>
-      <input placeholder="Buscar..." />
+      <input placeholder="Buscar..." value={search} onChange={e => setSearch(e.target.value)} />
       <table>
         <thead>
           <tr>
@@ -28,12 +74,12 @@ function DeviceTable({ onSelect }) {
           </tr>
         </thead>
         <tbody>
-          {devices.map(d => (
-            <tr key={d.id} onClick={() => onSelect(d.id)} style={{ cursor: 'pointer' }}>
+          {filtered.map(d => (
+            <tr key={d.deviceId} onClick={() => onSelect(d.deviceId)} style={{ cursor: 'pointer' }}>
               <td>{d.imei}</td>
               <td>{d.model}</td>
               <td>{d.serial}</td>
-              <td>{d.status}</td>
+              <td>{d.status?.battery ? `Bat ${d.status.battery}%` : ''}</td>
             </tr>
           ))}
         </tbody>
@@ -43,18 +89,43 @@ function DeviceTable({ onSelect }) {
 }
 
 function DeviceDetails({ id, onBack }) {
+  const [info, setInfo] = useState(null);
+  const [logs, setLogs] = useState([]);
+  useEffect(() => {
+    apiFetch(`/devices/${id}`).then(setInfo).catch(console.error);
+    apiFetch(`/logs/${id}`).then(d => setLogs(d.logs || [])).catch(console.error);
+  }, [id]);
+  const sendCommand = async (action) => {
+    try {
+      await apiFetch(`/api/device/${action}`, {
+        method: 'POST',
+        body: JSON.stringify({ deviceId: id })
+      });
+      alert('Comando enviado');
+    } catch (e) {
+      alert('Error enviando comando');
+    }
+  };
   return (
     <div>
       <h2>Dispositivo {id}</h2>
-      <p>Información detallada del dispositivo.</p>
+      {info && (
+        <div>
+          <p>Modelo: {info.model}</p>
+          <p>Serial: {info.serial}</p>
+          <p>IMEI: {info.imei}</p>
+          <p>Batería: {info.status?.battery ?? 'N/A'}%</p>
+        </div>
+      )}
       <div className="actions">
-        <button>Borrar Datos</button>
-        <button>Reiniciar</button>
+        <button onClick={() => sendCommand('wipe')}>Borrar Datos</button>
+        <button onClick={() => sendCommand('reboot')}>Reiniciar</button>
+        <button onClick={() => sendCommand('lock')}>Bloquear</button>
+        <button onClick={() => sendCommand('screenshot')}>Tomar Captura</button>
       </div>
       <h3>Historial de Logs</h3>
       <ul>
-        <li>Log 1...</li>
-        <li>Log 2...</li>
+        {logs.map((l, i) => <li key={i}>{JSON.stringify(l)}</li>)}
       </ul>
       <button onClick={onBack}>Volver</button>
     </div>
@@ -81,12 +152,19 @@ function PolicyEditor() {
 
 function App() {
   const [route, setRoute] = useState(window.location.hash || '#/dashboard');
+  const [token, setToken] = useState(localStorage.getItem('token') || '');
 
   useEffect(() => {
     const onHashChange = () => setRoute(window.location.hash || '#/dashboard');
     window.addEventListener('hashchange', onHashChange);
     return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
+
+  const handleTokenChange = (e) => {
+    const v = e.target.value;
+    setToken(v);
+    localStorage.setItem('token', v);
+  };
 
   let page;
   if (route === '#/dashboard') page = <Dashboard />;
@@ -106,6 +184,7 @@ function App() {
           <a href="#/devices">Dispositivos</a>
           <a href="#/policies">Políticas</a>
         </nav>
+        <input value={token} onChange={handleTokenChange} placeholder="JWT token" style={{ marginLeft: '1rem' }} />
       </header>
       <main style={{ padding: '1rem' }}>
         {page}


### PR DESCRIPTION
## Summary
- Expose `/devices` API endpoint returning basic device info and status
- Return stored status in `/devices/<id>` responses
- Connect admin frontend to backend: fetch devices, show counts and alerts, view device details and send control commands with JWT auth

## Testing
- `cd Servidor && pytest`

------
https://chatgpt.com/codex/tasks/task_b_68963626a1a88320ad6b4cdea4e487a0