### PR TITLE
Add web installer and admin panel enhancements

### DIFF
--- a/Servidor/install.py
+++ b/Servidor/install.py
@@ -1,0 +1,42 @@
+import os
+from flask import Flask, request, redirect, render_template_string
+from models import init_db
+
+app = Flask(__name__)
+
+FORM = """
+<!doctype html>
+<title>Instalación BizonMDM</title>
+<h1>Configuración inicial</h1>
+<form method="post">
+  <label>URL Base de Datos<input name="db" required></label><br>
+  <label>Clave JWT<input name="jwt" required></label><br>
+  <label>Clave Firebase<input name="fcm" required></label><br>
+  <label>Usuario admin<input name="user" required></label><br>
+  <label>Contraseña<input type="password" name="pwd" required></label><br>
+  <button type="submit">Instalar</button>
+</form>
+"""
+
+@app.route('/', methods=['GET', 'POST'])
+def install():
+    if request.method == 'POST':
+        db = request.form['db']
+        jwt = request.form['jwt']
+        fcm = request.form['fcm']
+        user = request.form['user']
+        pwd = request.form['pwd']
+        env_path = os.path.join(os.path.dirname(__file__), '.env')
+        with open(env_path, 'w', encoding='utf-8') as fh:
+            fh.write(f"DATABASE_URL={db}\nJWT_SECRET={jwt}\nADMIN_USER={user}\nADMIN_PASSWORD={pwd}\n")
+        key_path = os.path.join(os.path.dirname(__file__), 'fcm_key.txt')
+        with open(key_path, 'w', encoding='utf-8') as fh:
+            fh.write(fcm)
+        os.environ['DATABASE_URL'] = db
+        os.environ['JWT_SECRET'] = jwt
+        init_db()
+        return redirect('/admin')
+    return render_template_string(FORM)
+
+if __name__ == '__main__':
+    app.run()

--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -17,13 +17,19 @@ import hashlib
 import urllib.request
 
 from models import Device, LogEntry, Command, SessionLocal, init_db
+from sqlalchemy import text
 
 app = Flask(__name__)
 
 
 # Configuración ---------------------------------------------------------------
 JWT_SECRET = os.getenv("JWT_SECRET")
+# La clave de Firebase puede venir de variable de entorno o de un archivo
 FCM_SERVER_KEY = os.getenv("FCM_SERVER_KEY")
+FCM_KEY_FILE = os.path.join(os.path.dirname(__file__), "fcm_key.txt")
+if not FCM_SERVER_KEY and os.path.exists(FCM_KEY_FILE):
+    with open(FCM_KEY_FILE, "r", encoding="utf-8") as fh:
+        FCM_SERVER_KEY = fh.read().strip()
 FCM_URL = "https://fcm.googleapis.com/fcm/send"
 logging.basicConfig(filename="server.log", level=logging.INFO,
                     format="%(asctime)s %(levelname)s %(message)s")
@@ -270,6 +276,48 @@ def _send_fcm_message(token: str | None, payload: dict) -> None:
             pass
     except Exception as exc:
         logging.warning("Error enviando FCM: %s", exc)
+
+
+@app.route('/api/status', methods=['GET'])
+def api_status():
+    """Verifica el estado básico del servidor y dependencias."""
+    db_ok = False
+    try:
+        with get_session() as db:
+            db.execute(text("SELECT 1"))
+        db_ok = True
+    except Exception:
+        db_ok = False
+    firebase_ok = bool(FCM_SERVER_KEY)
+    return jsonify({'database': db_ok, 'firebase': firebase_ok}), 200
+
+
+@app.route('/api/firebase-key', methods=['GET', 'POST'])
+def api_firebase_key():
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+    global FCM_SERVER_KEY
+    if request.method == 'POST':
+        data = request.get_json() or {}
+        key = data.get('key')
+        if not key:
+            return jsonify({'success': False, 'message': 'key requerido'}), 400
+        FCM_SERVER_KEY = key
+        with open(FCM_KEY_FILE, 'w', encoding='utf-8') as fh:
+            fh.write(key)
+        return jsonify({'success': True}), 200
+    return jsonify({'key': FCM_SERVER_KEY or ''}), 200
+
+
+@app.route('/api/test-fcm', methods=['POST'])
+def api_test_fcm():
+    if not require_auth(request):
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+    with get_session() as db:
+        devices = db.query(Device).all()
+    for d in devices:
+        _send_fcm_message(d.fcm_token, {'action': 'test_message'})
+    return jsonify({'success': True, 'sent': len(devices)}), 200
 
 
 @app.route('/api/device/wipe', methods=['POST'])

--- a/admin-frontend/app.jsx
+++ b/admin-frontend/app.jsx
@@ -14,6 +14,21 @@ async function apiFetch(path, options = {}) {
   return res.json();
 }
 
+function ServerStatus() {
+  const [status, setStatus] = useState(null);
+  useEffect(() => {
+    apiFetch('/api/status').then(setStatus).catch(() => setStatus({}));
+  }, []);
+  const ok = status && status.database && status.firebase;
+  const color = ok ? 'green' : 'red';
+  return (
+    <span
+      title={`DB:${status?.database ? 'ok' : 'fail'} Firebase:${status?.firebase ? 'ok' : 'fail'}`}
+      style={{ display: 'inline-block', width: '10px', height: '10px', borderRadius: '50%', backgroundColor: color, marginLeft: '0.5rem' }}
+    />
+  );
+}
+
 function Dashboard() {
   const [devices, setDevices] = useState([]);
   useEffect(() => {
@@ -118,6 +133,41 @@ function DeviceLogs({ id }) {
   );
 }
 
+function Config() {
+  const [key, setKey] = useState('');
+  useEffect(() => {
+    apiFetch('/api/firebase-key').then(d => setKey(d.key || '')).catch(console.error);
+  }, []);
+  const save = () => {
+    apiFetch('/api/firebase-key', { method: 'POST', body: JSON.stringify({ key }) })
+      .then(() => alert('Guardado'))
+      .catch(() => alert('Error'));
+  };
+  const test = () => {
+    apiFetch('/api/test-fcm', { method: 'POST' })
+      .then(r => alert(`Notificación enviada a ${r.sent} dispositivos`))
+      .catch(() => alert('Error'));
+  };
+  return (
+    <div>
+      <h2>Configuración de Firebase</h2>
+      <input value={key} onChange={e => setKey(e.target.value)} placeholder="FCM Server Key" />
+      <button onClick={save}>Guardar</button>
+      <button onClick={test}>Probar conexión</button>
+    </div>
+  );
+}
+
+function Welcome({ onDone }) {
+  return (
+    <div>
+      <h2>Bienvenido a BizonMDM</h2>
+      <p>Desde aquí puedes aprovisionar dispositivos por QR, gestionar políticas y más.</p>
+      <button onClick={onDone}>Comenzar</button>
+    </div>
+  );
+}
+
 function DeviceDetails({ id, onBack }) {
   const [info, setInfo] = useState(null);
   useEffect(() => {
@@ -179,6 +229,7 @@ function PolicyEditor() {
 function App() {
   const [route, setRoute] = useState(window.location.hash || '#/dashboard');
   const [token, setToken] = useState(localStorage.getItem('token') || '');
+  const [welcome, setWelcome] = useState(!localStorage.getItem('welcomeSeen'));
 
   useEffect(() => {
     const onHashChange = () => setRoute(window.location.hash || '#/dashboard');
@@ -192,6 +243,10 @@ function App() {
     localStorage.setItem('token', v);
   };
 
+  if (welcome) {
+    return <Welcome onDone={() => { localStorage.setItem('welcomeSeen', '1'); setWelcome(false); }} />;
+  }
+
   let page;
   if (route === '#/dashboard') page = <Dashboard />;
   else if (route === '#/devices') page = <DeviceTable onSelect={(id) => window.location.hash = `#/devices/${id}`} />;
@@ -199,6 +254,7 @@ function App() {
     const id = route.split('/')[2];
     page = <DeviceDetails id={id} onBack={() => window.location.hash = '#/devices'} />;
   } else if (route === '#/policies') page = <PolicyEditor />;
+  else if (route === '#/config') page = <Config />;
   else page = <Dashboard />;
 
   return (
@@ -209,7 +265,9 @@ function App() {
           <a href="#/dashboard">Dashboard</a>
           <a href="#/devices">Dispositivos</a>
           <a href="#/policies">Políticas</a>
+          <a href="#/config">Config</a>
         </nav>
+        <ServerStatus />
         <input value={token} onChange={handleTokenChange} placeholder="JWT token" style={{ marginLeft: '1rem' }} />
       </header>
       <main style={{ padding: '1rem' }}>


### PR DESCRIPTION
## Summary
- Add server status, Firebase key management and test notification endpoints
- Provide simple web-based installer for initial configuration
- Enhance admin UI with server status indicator, Firebase settings page and welcome screen

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68963c6376388320833e10feb1256410