### PR TITLE
docs: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,15 @@ cd Servidor
 python3 -m venv venv       # opcional
 source venv/bin/activate   # opcional
 pip install -r requirements.txt
+python server.py --init-db # solo la primera vez
 python server.py
 ```
 
-Por defecto escuchará en `http://0.0.0.0:5000/`. Se pueden cambiar el host o el puerto mediante las variables `BIZON_HOST` y `BIZON_PORT`.
+Por defecto escuchará en `http://0.0.0.0:5000/`. Se pueden cambiar el host o el puerto mediante las variables `BIZON_HOST` y `BIZON_PORT`. También puedes proteger los endpoints estableciendo `JWT_SECRET` y habilitar notificaciones push con `FCM_SERVER_KEY`.
+
+```bash
+BIZON_HOST=127.0.0.1 BIZON_PORT=8000 JWT_SECRET=secreto FCM_SERVER_KEY=tu_clave python server.py
+```
 
 Consulta el [README del servidor](Servidor/README.md) para ver los endpoints disponibles y ejemplos de peticiones.
 

--- a/Servidor/MANUAL.md
+++ b/Servidor/MANUAL.md
@@ -44,13 +44,13 @@ Esto inicializa la base de datos (archivo SQLite) la primera vez y luego levanta
  * Running on http://0.0.0.0:5000/
 ```
 
-Se pueden modificar la dirección y el puerto mediante las variables de entorno `BIZON_HOST` y `BIZON_PORT`. Si defines `BIZON_TOKEN`, todas las peticiones deberán incluir el encabezado `Authorization: Bearer <token>`.
+Se pueden modificar la dirección y el puerto mediante las variables de entorno `BIZON_HOST` y `BIZON_PORT`. Si defines `JWT_SECRET`, todas las peticiones deberán incluir un token JWT válido en el encabezado `Authorization: Bearer <token>`.
 La ruta del archivo de base de datos puede cambiarse con `BIZON_DB` (por defecto `bizon.db`).
 
 ## 5. Características y funcionamiento interno
 
 - **Persistencia de datos**: se utiliza SQLite a través de SQLAlchemy. Las tablas (dispositivos, logs y comandos) están definidas en `models.py`. La función `init_db()` crea las tablas necesarias si no existen.
-- **Seguridad opcional**: al definir `BIZON_TOKEN`, los endpoints exigen autenticación mediante el encabezado mencionado.
+- **Seguridad opcional**: al definir `JWT_SECRET`, los endpoints exigen autenticación mediante un token JWT en el encabezado mencionado.
 - **Endpoints principales**:
   - `/devices/register` para registrar un dispositivo (`POST`).
   - `/devices/status` para actualizar su estado (`POST`).

--- a/Servidor/README.md
+++ b/Servidor/README.md
@@ -57,10 +57,12 @@ La base de datos se almacena en el archivo indicado por `BIZON_DB` (por defecto
 
 ### Notificaciones push
 
-Si estableces la variable de entorno `FCM_SERVER_KEY` el servidor enviará
+Si defines la variable de entorno `FCM_SERVER_KEY` el servidor enviará
 una notificación de Firebase Cloud Messaging cada vez que se encole un
 comando para un dispositivo. La aplicación debe incluir su `fcmToken` al
 registrarse o actualizar su estado para que el servidor pueda utilizarlo.
+Si la variable no está configurada, el servidor intentará leer la clave
+desde un archivo `fcm_key.txt` en este mismo directorio.
 
 ### Generar QR de aprovisionamiento
 

--- a/instalacion_bizonmdm.html
+++ b/instalacion_bizonmdm.html
@@ -257,10 +257,10 @@ source venv/bin/activate   # En Linux/macOS
             </li>
             <li>
                 <h4>Configuración de Variables de Entorno (Opcional)</h4>
-                <p>Puedes personalizar el host, puerto y añadir un token de autenticación para el servidor.</p>
-                <pre><code>BIZON_HOST=127.0.0.1 BIZON_PORT=8000 BIZON_TOKEN=secreto python server.py</code></pre>
+                <p>Puedes personalizar el host, puerto y añadir un token de autenticación para el servidor. También puedes habilitar notificaciones push con una clave de Firebase.</p>
+                <pre><code>BIZON_HOST=127.0.0.1 BIZON_PORT=8000 JWT_SECRET=secreto FCM_SERVER_KEY=tu_clave python server.py</code></pre>
                 <div class="warning">
-                    Si defines <code>BIZON_TOKEN</code>, todas las peticiones al servidor deberán incluir el encabezado <code>Authorization: Bearer &lt;token&gt;</code>.
+                    Si defines <code>JWT_SECRET</code>, todas las peticiones al servidor deberán incluir un token JWT válido en el encabezado <code>Authorization: Bearer &lt;token&gt;</code>.
                 </div>
             </li>
         </ol>


### PR DESCRIPTION
## Summary
- document JWT_SECRET and FCM_SERVER_KEY in installation guide
- expand server setup instructions for first-time init and environment variables
- mention FCM key file fallback in server README
- align manual with JWT-based auth

## Testing
- `pytest -q Servidor/tests/test_server.py`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68963ec82db883209d5b1cd599eea0bc