### PR TITLE
Move installation script to project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Esta versión incluye un proceso de instalación simplificado para el servidor d
 
 ## Instalación del servidor
 
-1. Clona este repositorio y entra en el directorio `Servidor`.
+1. Clona este repositorio.
 2. Instala las dependencias y ejecuta el script de instalación:
    ```bash
-   pip install -r requirements.txt
+   pip install -r Servidor/requirements.txt
    python install_script.py
    ```
 3. Abre `http://localhost:5000/install` en tu navegador y completa el formulario con:
@@ -25,7 +25,7 @@ Esta versión incluye un proceso de instalación simplificado para el servidor d
 Para iniciar el servidor después de la instalación:
 
 ```bash
-python server.py
+python Servidor/server.py
 ```
 
 ## Panel de administración

--- a/install_script.py
+++ b/install_script.py
@@ -1,7 +1,7 @@
 import os
 import hashlib
 from flask import Flask, request, redirect, send_from_directory
-from models import init_db, SessionLocal, Admin
+from Servidor.models import init_db, SessionLocal, Admin
 
 app = Flask(__name__)
 
@@ -15,7 +15,7 @@ def install():
         user = request.form['user']
         pwd = request.form['pwd']
 
-        base_dir = os.path.dirname(__file__)
+        base_dir = os.path.join(os.path.dirname(__file__), 'Servidor')
         env_path = os.path.join(base_dir, '.env')
         with open(env_path, 'w', encoding='utf-8') as fh:
             fh.write(f"DATABASE_URL={db}\nJWT_SECRET={jwt}\n")
@@ -33,7 +33,7 @@ def install():
                 session.add(Admin(username=user, password=hashed))
                 session.commit()
         return redirect('/admin')
-    root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    root_dir = os.path.dirname(__file__)
     return send_from_directory(root_dir, 'instalacion_bizonmdm.html')
 
 


### PR DESCRIPTION
## Summary
- relocate the Flask installation script to the repository root so it can be invoked directly and still configure files under `Servidor`
- update documentation to install backend dependencies and run the installer from the project root

## Testing
- `pip install -r Servidor/requirements.txt`
- `pytest Servidor/tests/test_server.py`

------
https://chatgpt.com/codex/tasks/task_b_68964c84d88c832080cd4e7cb926026d