### PR TITLE
Streamline BizonMDM installation and add Firebase setup page

### DIFF
--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -23,13 +23,17 @@ app = Flask(__name__)
 
 
 # Configuración ---------------------------------------------------------------
+BASE_DIR = os.path.dirname(__file__)
+ENV_PATH = os.path.join(BASE_DIR, '.env')
+if os.path.exists(ENV_PATH):
+    with open(ENV_PATH, 'r', encoding='utf-8') as fh:
+        for line in fh:
+            if '=' in line:
+                k, v = line.strip().split('=', 1)
+                os.environ.setdefault(k, v)
+
 JWT_SECRET = os.getenv("JWT_SECRET")
-# La clave de Firebase puede venir de variable de entorno o de un archivo
 FCM_SERVER_KEY = os.getenv("FCM_SERVER_KEY")
-FCM_KEY_FILE = os.path.join(os.path.dirname(__file__), "fcm_key.txt")
-if not FCM_SERVER_KEY and os.path.exists(FCM_KEY_FILE):
-    with open(FCM_KEY_FILE, "r", encoding="utf-8") as fh:
-        FCM_SERVER_KEY = fh.read().strip()
 FCM_URL = "https://fcm.googleapis.com/fcm/send"
 logging.basicConfig(filename="server.log", level=logging.INFO,
                     format="%(asctime)s %(levelname)s %(message)s")
@@ -292,8 +296,8 @@ def api_status():
     return jsonify({'database': db_ok, 'firebase': firebase_ok}), 200
 
 
-@app.route('/api/firebase-key', methods=['GET', 'POST'])
-def api_firebase_key():
+@app.route('/api/config/fcm', methods=['GET', 'POST'])
+def api_config_fcm():
     if not require_auth(request):
         return jsonify({'success': False, 'message': 'Unauthorized'}), 401
     global FCM_SERVER_KEY
@@ -302,10 +306,16 @@ def api_firebase_key():
         key = data.get('key')
         if not key:
             return jsonify({'success': False, 'message': 'key requerido'}), 400
-        FCM_SERVER_KEY = key
-        with open(FCM_KEY_FILE, 'w', encoding='utf-8') as fh:
-            fh.write(key)
-        return jsonify({'success': True}), 200
+        FCM_SERVER_KEY = key.strip()
+        env_lines = []
+        if os.path.exists(ENV_PATH):
+            with open(ENV_PATH, 'r', encoding='utf-8') as fh:
+                env_lines = [l for l in fh.readlines() if not l.startswith('FCM_SERVER_KEY=')]
+        env_lines.append(f'FCM_SERVER_KEY={FCM_SERVER_KEY}\n')
+        with open(ENV_PATH, 'w', encoding='utf-8') as fh:
+            fh.writelines(env_lines)
+        os.environ['FCM_SERVER_KEY'] = FCM_SERVER_KEY
+        return jsonify({'success': True, 'message': 'Clave de Firebase guardada correctamente'}), 200
     return jsonify({'key': FCM_SERVER_KEY or ''}), 200
 
 

--- a/admin-frontend/app.jsx
+++ b/admin-frontend/app.jsx
@@ -136,27 +136,49 @@ function DeviceLogs({ id }) {
   );
 }
 
-function Config() {
+function FirebaseConfigForm() {
   const [key, setKey] = useState('');
+  const [message, setMessage] = useState('');
   useEffect(() => {
-    apiFetch('/api/firebase-key').then(d => setKey(d.key || '')).catch(console.error);
+    apiFetch('/api/config/fcm').then(d => setKey(d.key || '')).catch(console.error);
   }, []);
   const save = () => {
-    apiFetch('/api/firebase-key', { method: 'POST', body: JSON.stringify({ key }) })
-      .then(() => alert('Guardado'))
-      .catch(() => alert('Error'));
+    apiFetch('/api/config/fcm', { method: 'POST', body: JSON.stringify({ key }) })
+      .then(() => setMessage('Clave de Firebase guardada correctamente'))
+      .catch(() => setMessage('Error al guardar la clave'));
   };
   const test = () => {
     apiFetch('/api/test-fcm', { method: 'POST' })
-      .then(r => alert(`Notificación enviada a ${r.sent} dispositivos`))
-      .catch(() => alert('Error'));
+      .then(r => setMessage(`Notificación enviada a ${r.sent} dispositivos`))
+      .catch(() => setMessage('Error al conectar con Firebase'));
   };
   return (
     <div>
-      <h2>Configuración de Firebase</h2>
       <input value={key} onChange={e => setKey(e.target.value)} placeholder="FCM Server Key" />
-      <button onClick={save}>Guardar</button>
-      <button onClick={test}>Probar conexión</button>
+      <div>
+        <button onClick={save}>Guardar</button>
+        <button onClick={test}>Probar conexión</button>
+      </div>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}
+
+function Config() {
+  return (
+    <div>
+      <h2>Configuración de Firebase</h2>
+      <FirebaseConfigForm />
+    </div>
+  );
+}
+
+function FirstSteps() {
+  return (
+    <div>
+      <h2>Primeros pasos</h2>
+      <p>Ingresa la clave de Firebase para habilitar las notificaciones.</p>
+      <FirebaseConfigForm />
     </div>
   );
 }
@@ -246,7 +268,7 @@ function App() {
     localStorage.setItem('token', v);
   };
 
-  if (welcome) {
+  if (welcome && route !== '#/first-steps') {
     return <Welcome onDone={() => { localStorage.setItem('welcomeSeen', '1'); setWelcome(false); }} />;
   }
 
@@ -258,6 +280,7 @@ function App() {
     page = <DeviceDetails id={id} onBack={() => window.location.hash = '#/devices'} />;
   } else if (route === '#/policies') page = <PolicyEditor />;
   else if (route === '#/config') page = <Config />;
+  else if (route === '#/first-steps') page = <FirstSteps />;
   else page = <Dashboard />;
 
   return (

--- a/instalacion_bizonmdm.html
+++ b/instalacion_bizonmdm.html
@@ -3,16 +3,35 @@
 <head>
     <meta charset="UTF-8" />
     <title>Instalación BizonMDM</title>
+    <style>
+        body {font-family: Arial, sans-serif; background:#f4f4f4; margin:0; display:flex; align-items:center; justify-content:center; height:100vh;}
+        .container {background:#fff; padding:2rem; border-radius:8px; box-shadow:0 2px 8px rgba(0,0,0,0.1); width:360px;}
+        h1 {text-align:center; margin-bottom:1rem;}
+        label {display:block; margin-bottom:.5rem; font-weight:bold;}
+        input {width:100%; padding:.5rem; margin-top:.25rem; margin-bottom:1rem; border:1px solid #ccc; border-radius:4px;}
+        button {width:100%; padding:.75rem; background:#007bff; color:#fff; border:none; border-radius:4px; font-size:1rem; cursor:pointer;}
+        .logo {display:block; margin:0 auto 1rem auto; width:80px; height:auto;}
+    </style>
 </head>
 <body>
-    <h1>Configuración inicial de BizonMDM</h1>
-    <form action="/install" method="post">
-        <label>URL Base de Datos: <input name="db" required /></label><br />
-        <label>Clave JWT: <input name="jwt" required /></label><br />
-        <label>Clave Firebase:<br /><textarea name="fcm" required></textarea></label><br />
-        <label>Usuario admin: <input name="user" required /></label><br />
-        <label>Contraseña: <input type="password" name="pwd" required /></label><br />
-        <button type="submit">Instalar</button>
-    </form>
+    <div class="container">
+        <img src="logo.png" alt="BizonMDM" class="logo" />
+        <h1>Configuración Inicial</h1>
+        <form action="/install" method="post">
+            <label>URL Base de Datos:
+                <input name="db" required />
+            </label>
+            <label>Clave JWT:
+                <input name="jwt" required />
+            </label>
+            <label>Usuario admin:
+                <input name="user" required />
+            </label>
+            <label>Contraseña:
+                <input type="password" name="pwd" required />
+            </label>
+            <button type="submit">Instalar</button>
+        </form>
+    </div>
 </body>
 </html>

--- a/install_script.py
+++ b/install_script.py
@@ -11,7 +11,6 @@ def install():
     if request.method == 'POST':
         db = request.form['db']
         jwt = request.form['jwt']
-        fcm = request.form['fcm']
         user = request.form['user']
         pwd = request.form['pwd']
 
@@ -19,10 +18,6 @@ def install():
         env_path = os.path.join(base_dir, '.env')
         with open(env_path, 'w', encoding='utf-8') as fh:
             fh.write(f"DATABASE_URL={db}\nJWT_SECRET={jwt}\n")
-
-        key_path = os.path.join(base_dir, 'fcm_key.txt')
-        with open(key_path, 'w', encoding='utf-8') as fh:
-            fh.write(fcm)
 
         os.environ['DATABASE_URL'] = db
         os.environ['JWT_SECRET'] = jwt
@@ -32,7 +27,7 @@ def install():
                 hashed = hashlib.sha256(pwd.encode()).hexdigest()
                 session.add(Admin(username=user, password=hashed))
                 session.commit()
-        return redirect('/admin')
+        return redirect('/admin/#/first-steps')
     root_dir = os.path.dirname(__file__)
     return send_from_directory(root_dir, 'instalacion_bizonmdm.html')
 


### PR DESCRIPTION
## Summary
- Restyle and simplify the installer, focusing on DB and JWT settings
- Add backend endpoint and panel to configure Firebase after install
- Load .env automatically and persist FCM key via API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689659c16ab88320af041563ecd88e99