### PR TITLE
Add API installation endpoint and form integration

### DIFF
--- a/Servidor/install_script.py
+++ b/Servidor/install_script.py
@@ -1,0 +1,28 @@
+import os
+from models import init_db
+
+
+def install_application(db_host: str, db_name: str, db_user: str, db_pass: str, jwt_secret: str) -> None:
+    """Configura el entorno de la aplicación y ejecuta las migraciones."""
+    db_url = f"postgresql+psycopg2://{db_user}:{db_pass}@{db_host}/{db_name}"
+    base_dir = os.path.dirname(__file__)
+    env_path = os.path.join(base_dir, '.env')
+    with open(env_path, 'w', encoding='utf-8') as fh:
+        fh.write(f"DATABASE_URL={db_url}\nJWT_SECRET={jwt_secret}\n")
+
+    os.environ['DATABASE_URL'] = db_url
+    os.environ['JWT_SECRET'] = jwt_secret
+    init_db()
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Instala la aplicación BizonMDM')
+    parser.add_argument('--db-host', required=True)
+    parser.add_argument('--db-name', required=True)
+    parser.add_argument('--db-user', required=True)
+    parser.add_argument('--db-pass', required=True)
+    parser.add_argument('--jwt-secret', required=True)
+    args = parser.parse_args()
+    install_application(args.db_host, args.db_name, args.db_user, args.db_pass, args.jwt_secret)
+    print('Instalación completada.')

--- a/Servidor/server.py
+++ b/Servidor/server.py
@@ -18,6 +18,7 @@ import urllib.request
 
 from models import Device, LogEntry, Command, SessionLocal, init_db
 from sqlalchemy import text
+from install_script import install_application
 
 app = Flask(__name__)
 
@@ -440,6 +441,22 @@ def get_commands(device_id: str):
             db.delete(c)
         db.commit()
     return jsonify(cmds), 200
+
+
+@app.route('/api/install', methods=['POST'])
+def install():
+    data = request.json
+    db_host = data.get('db_host')
+    db_name = data.get('db_name')
+    db_user = data.get('db_user')
+    db_pass = data.get('db_pass')
+    jwt_secret = data.get('jwt_secret')
+
+    try:
+        install_application(db_host, db_name, db_user, db_pass, jwt_secret)
+        return jsonify({"success": True, "message": "Instalación completada."})
+    except Exception as e:
+        return jsonify({"success": False, "message": str(e)}), 500
 
 if __name__ == '__main__':
     import argparse

--- a/instalacion_bizonmdm.html
+++ b/instalacion_bizonmdm.html
@@ -11,27 +11,78 @@
         input {width:100%; padding:.5rem; margin-top:.25rem; margin-bottom:1rem; border:1px solid #ccc; border-radius:4px;}
         button {width:100%; padding:.75rem; background:#007bff; color:#fff; border:none; border-radius:4px; font-size:1rem; cursor:pointer;}
         .logo {display:block; margin:0 auto 1rem auto; width:80px; height:auto;}
+        .alert-message {margin-top:1rem; padding:.75rem; border-radius:4px;}
+        .alert-success {background:#d4edda; color:#155724;}
+        .alert-error {background:#f8d7da; color:#721c24;}
     </style>
 </head>
 <body>
     <div class="container">
         <img src="logo.png" alt="BizonMDM" class="logo" />
         <h1>Configuración Inicial</h1>
-        <form action="/install" method="post">
-            <label>URL Base de Datos:
-                <input name="db" required />
+        <form id="installationForm">
+            <label>Host Base de Datos:
+                <input name="db_host" required />
+            </label>
+            <label>Nombre Base de Datos:
+                <input name="db_name" required />
+            </label>
+            <label>Usuario Base de Datos:
+                <input name="db_user" required />
+            </label>
+            <label>Contraseña Base de Datos:
+                <input type="password" name="db_pass" required />
             </label>
             <label>Clave JWT:
-                <input name="jwt" required />
+                <input name="jwt_secret" required />
             </label>
-            <label>Usuario admin:
-                <input name="user" required />
-            </label>
-            <label>Contraseña:
-                <input type="password" name="pwd" required />
-            </label>
-            <button type="submit">Instalar</button>
+            <button id="installBtn" type="submit">Instalar</button>
         </form>
+        <div id="message" class="alert-message" style="display:none;"></div>
     </div>
+    <script>
+        document.getElementById('installationForm').addEventListener('submit', function(event) {
+            event.preventDefault();
+
+            const installBtn = document.getElementById('installBtn');
+            const messageDiv = document.getElementById('message');
+            installBtn.disabled = true;
+            messageDiv.style.display = 'none';
+            messageDiv.className = 'alert-message';
+
+            const formData = new FormData(event.target);
+            const data = Object.fromEntries(formData.entries());
+
+            messageDiv.innerText = 'Iniciando instalación... Por favor, espera.';
+            messageDiv.style.display = 'block';
+
+            fetch('/api/install', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(data)
+            })
+            .then(response => response.json())
+            .then(result => {
+                if (result.success) {
+                    messageDiv.className = 'alert-message alert-success';
+                    messageDiv.innerText = '¡Instalación completada con éxito! Redirigiendo al panel...';
+                    setTimeout(() => {
+                        window.location.href = '/admin';
+                    }, 3000);
+                } else {
+                    messageDiv.className = 'alert-message alert-error';
+                    messageDiv.innerText = `Error: ${result.message}`;
+                    installBtn.disabled = false;
+                }
+            })
+            .catch(error => {
+                messageDiv.className = 'alert-message alert-error';
+                messageDiv.innerText = `Error de conexión: ${error.message}`;
+                installBtn.disabled = false;
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add /api/install endpoint to server to trigger application setup
- create install_script module with install_application function
- update installation HTML form to submit data asynchronously

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6896639726c483209327f407451ab19e