### PR TITLE
docs: document auth security

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,28 @@ Serve the contents of `web-admin/` with your preferred static server.
 ```
 
 See [docs/DEV_SETUP.md](docs/DEV_SETUP.md) for detailed setup instructions.
+
+## Seguridad
+
+- Los endpoints sensibles `/panel/install` y `/panel/api/auth/*` están protegidos por un límite de 5 peticiones cada 10 segundos mediante `flask-limiter`:
+
+  ```python
+  @limiter.limit("5 per 10 seconds")
+  ```
+
+- Durante la instalación se exige que la contraseña del administrador sea fuerte (mínimo 14 caracteres con mayúsculas, minúsculas y números).
+
+- La API de autenticación emite tokens de acceso y de refresco. El token de refresco se rota en cada petición y el JTI del token previo se guarda en la lista negra (`jwt_blacklist`).
+
+  ```bash
+  # iniciar sesión
+  curl -X POST http://localhost:5000/panel/api/auth/login \\
+       -H 'Content-Type: application/json' \\
+       -d '{"email":"admin@example.com","password":"<contraseña>"}'
+
+  # renovar token
+  curl -X POST http://localhost:5000/panel/api/auth/refresh \\
+       -H 'Authorization: Bearer <refresh_token>'
+  ```
+
+- Todas las operaciones críticas se registran en la tabla `audit_logs` para auditoría.


### PR DESCRIPTION
## Summary
- document rate limiting for installer and auth endpoints
- note strong password requirements and audit logging
- describe access/refresh token rotation and blacklist

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_b_6896796b4acc8320a6fdc64d80eb81d1