### PR TITLE
docs: add user and authentication sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,43 @@ python server/Servidor/server.py
 
 La interfaz web ubicada en `server/admin-frontend/` obtiene la lista de dispositivos desde la API del servidor y permite enviar acciones como "Borrar datos" o "Bloquear dispositivo". También muestra un indicador de estado que comprueba la conexión con la base de datos y la validez de la clave de Firebase mediante el endpoint `/api/status`.
 
+## Gestión de usuarios y autenticación
+
+BizonMDM permite registrar usuarios que acceden al panel cliente.
+
+### Creación de usuarios
+
+```bash
+curl -X POST https://mi-servidor/api/users \
+  -H "Authorization: Bearer <token_admin>" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"jane","password":"secreta","role":"cliente"}'
+```
+
+### Inicio de sesión
+
+```bash
+curl -X POST https://mi-servidor/api/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"jane","password":"secreta"}'
+```
+
+La respuesta incluye un token JWT usado para llamadas posteriores.
+
+### Permisos y roles
+
+Los roles disponibles son `admin`, `operador` y `cliente`. Cada uno limita el acceso a los endpoints y al panel según sus privilegios.
+
+### Uso del panel cliente
+
+Los usuarios autenticados pueden acceder a `https://mi-servidor/cliente` para gestionar sus propios dispositivos, revisar el estado y ejecutar acciones permitidas.
+
+### Consideraciones de seguridad
+
+- Obliga HTTPS para todas las peticiones.
+- Almacena las contraseñas con algoritmos de hash seguros (p. ej., bcrypt).
+- Define tiempos de expiración cortos para los tokens JWT y rotación mediante refresh.
+
 ## Licencia
 
 Este proyecto se distribuye bajo los términos de la licencia MIT. Consulta el archivo `LICENSE` para más información.

--- a/documentation.html
+++ b/documentation.html
@@ -91,6 +91,7 @@
         <h3>Operación</h3>
         <a href="#uso-panel">Uso del panel</a>
         <a href="#gestion-dispositivos">Gestión de dispositivos</a>
+        <a href="#gestion-usuarios">Gestión de usuarios</a>
         <a href="#seguridad">Seguridad</a>
         <a href="#respaldo">Backups & actualización</a>
         <a href="#solucion-fallos">Solución de problemas</a>
@@ -332,6 +333,27 @@ DATABASE_URL=sqlite:///bizon.db</code></pre>
       <li><strong>Alta</strong>: instale la app, inicie sesión y permita permisos requeridos (administrador del dispositivo, notificaciones, accesibilidad si aplica).</li>
       <li><strong>Sincronización</strong>: el dispositivo reporta estado periódico y recibe órdenes vía FCM + pull de API.</li>
       <li><strong>Baja</strong>: desinscribir desde el panel o restablecer de fábrica el dispositivo.</li>
+    </ul>
+    <h2 id="gestion-usuarios">Gestión de usuarios y autenticación</h2>
+    <p>El servidor expone endpoints para crear cuentas, iniciar sesión y controlar permisos.</p>
+    <h3>Creación de usuarios</h3>
+    <pre><code>curl -X POST https://mi-servidor/api/users \
+  -H "Authorization: Bearer &lt;token_admin&gt;" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"jane","password":"secreta","role":"cliente"}'</code></pre>
+    <h3>Inicio de sesión</h3>
+    <pre><code>curl -X POST https://mi-servidor/api/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"jane","password":"secreta"}'</code></pre>
+    <h3>Permisos y roles</h3>
+    <p>Los roles <code>admin</code>, <code>operador</code> y <code>cliente</code> delimitan el acceso a módulos y endpoints.</p>
+    <h3>Panel cliente</h3>
+    <p>Tras autenticarse, los usuarios acceden al panel en <code>/cliente</code> para gestionar sus dispositivos.</p>
+    <h3>Consideraciones de seguridad</h3>
+    <ul>
+      <li>Requiere HTTPS y tokens JWT válidos.</li>
+      <li>Las contraseñas se guardan con hash seguro (bcrypt).</li>
+      <li>Revoca tokens comprometidos y usa expiración corta.</li>
     </ul>
 
     <h2 id="seguridad">Seguridad</h2>


### PR DESCRIPTION
## Summary
- document user creation, login, roles and client panel usage in README and documentation.html

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689787b126948320b935d9cfdf1e4d3e