### PR TITLE
Add subdomain-based config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ BizonMDM es una plataforma de Mobile Device Management (MDM) de código abierto.
   - `admin-frontend/`: interfaz web de administración construida en React.
   - `docker-compose.yml`: ejemplo de despliegue con contenedores.
   - `install_script.py` e `instalacion_bizonmdm.html`: utilidades para la instalación.
+  - `SUBDOMAIN_SETUP.md`: ejemplo de configuración de NGINX/Apache para servir varios subdominios.
 
 ## Instalación del servidor
 

--- a/server/SUBDOMAIN_SETUP.md
+++ b/server/SUBDOMAIN_SETUP.md
@@ -1,0 +1,36 @@
+# Configuración de subdominios
+
+Este ejemplo muestra cómo redirigir múltiples subdominios a la misma aplicación
+BizonMDM y permitir que el frontend cargue la configuración adecuada según el
+subdominio.
+
+## NGINX
+
+```nginx
+server {
+    listen 80;
+    server_name *.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+## Apache
+
+```apache
+<VirtualHost *:80>
+    ServerName example.com
+    ServerAlias *.example.com
+    ProxyPreserveHost On
+    ProxyPass / http://127.0.0.1:5000/
+    ProxyPassReverse / http://127.0.0.1:5000/
+</VirtualHost>
+```
+
+Con estas directivas, cualquier subdominio de `example.com` será atendido por el
+mismo backend. El frontend puede detectar el subdominio y solicitar al servidor
+su configuración específica.

--- a/server/Servidor/configs/default.json
+++ b/server/Servidor/configs/default.json
@@ -1,0 +1,3 @@
+{
+  "title": "Bizon MDM Admin"
+}

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -320,6 +320,25 @@ def api_config_fcm():
     return jsonify({'key': FCM_SERVER_KEY or ''}), 200
 
 
+@app.route('/api/config/tenant/<tenant>', methods=['GET'])
+def api_config_tenant(tenant: str):
+    """Devuelve la configuración específica para un subdominio.
+
+    Busca un archivo JSON en el directorio ``configs`` con el nombre del
+    subdominio. Si no existe, intenta cargar ``default.json``. Si tampoco
+    está presente, devuelve un objeto vacío con estado 404.
+    """
+    config_dir = os.path.join(BASE_DIR, 'configs')
+    specific = os.path.join(config_dir, f'{tenant}.json')
+    fallback = os.path.join(config_dir, 'default.json')
+    path = specific if os.path.exists(specific) else fallback
+    if not os.path.exists(path):
+        return jsonify({}), 404
+    with open(path, 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+    return jsonify(data), 200
+
+
 @app.route('/api/test-fcm', methods=['POST'])
 def api_test_fcm():
     if not require_auth(request):

--- a/server/admin-frontend/app.jsx
+++ b/server/admin-frontend/app.jsx
@@ -255,6 +255,15 @@ function App() {
   const [route, setRoute] = useState(window.location.hash || '#/dashboard');
   const [token, setToken] = useState(localStorage.getItem('token') || '');
   const [welcome, setWelcome] = useState(!localStorage.getItem('welcomeSeen'));
+  const [tenantConfig, setTenantConfig] = useState({});
+
+  useEffect(() => {
+    const sub = window.location.hostname.split('.')[0];
+    fetch(`/api/config/tenant/${sub}`)
+      .then(r => r.ok ? r.json() : {})
+      .then(setTenantConfig)
+      .catch(() => setTenantConfig({}));
+  }, []);
 
   useEffect(() => {
     const onHashChange = () => setRoute(window.location.hash || '#/dashboard');
@@ -286,7 +295,7 @@ function App() {
   return (
     <div>
       <header>
-        <h1>Bizon MDM Admin</h1>
+        <h1>{tenantConfig.title || 'Bizon MDM Admin'}</h1>
         <nav>
           <a href="#/dashboard">Dashboard</a>
           <a href="#/devices">Dispositivos</a>


### PR DESCRIPTION
## Summary
- Document NGINX/Apache examples for serving all subdomains from one BizonMDM instance
- Allow backend to serve tenant-specific configuration files
- Frontend loads configuration by subdomain to customize title

## Testing
- `cd server/Servidor && pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689787b05c548320b0ecf8124e791a78