### PR TITLE
docs: expand authentication and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ BizonMDM es una plataforma de Mobile Device Management (MDM) de código abierto.
 
 ## Instalación del servidor
 
+### Requisitos previos
+
+- Python 3.10+ y `pip`.
+- Node.js 18+ si deseas recompilar el panel React.
+- Una base de datos SQL (PostgreSQL, MySQL/MariaDB o SQLite para pruebas).
+- Clave de servidor de Firebase Cloud Messaging.
+
+### Pasos
+
 1. Clona este repositorio.
 2. Instala las dependencias y ejecuta el script de instalación:
 
@@ -40,11 +49,19 @@ python server/install_script.py
    - La ejecución de las migraciones de Alembic para preparar la base de datos.
    - La creación del usuario administrador.
 5. Tras una instalación exitosa serás redirigido al panel de administración.
-
-Para iniciar el servidor después de la instalación:
+6. (Opcional) Compila la interfaz web si realizaste cambios en `server/admin-frontend/`:
 
 ```bash
-python server/Servidor/server.py
+cd server/admin-frontend
+npm install
+npm run build
+```
+
+7. Inicia el servidor y comprueba el estado:
+
+```bash
+python server/Servidor/server.py &
+curl http://localhost:5000/api/status
 ```
 
 ## Panel de administración
@@ -82,11 +99,26 @@ Los roles disponibles son `admin`, `operador` y `cliente`. Cada uno limita el ac
 
 Los usuarios autenticados pueden acceder a `https://mi-servidor/cliente` para gestionar sus propios dispositivos, revisar el estado y ejecutar acciones permitidas.
 
+#### Ejemplo: listar dispositivos
+
+```bash
+curl -H "Authorization: Bearer <token_cliente>" https://mi-servidor/api/devices
+```
+
+Con el identificador de un dispositivo también es posible enviar acciones:
+
+```bash
+curl -X POST https://mi-servidor/api/devices/42/lock \
+  -H "Authorization: Bearer <token_cliente>"
+```
+
 ### Consideraciones de seguridad
 
 - Obliga HTTPS para todas las peticiones.
 - Almacena las contraseñas con algoritmos de hash seguros (p. ej., bcrypt).
 - Define tiempos de expiración cortos para los tokens JWT y rotación mediante refresh.
+- Deshabilita o protege el endpoint `/install` una vez finalizada la configuración.
+- Limita los intentos de inicio de sesión para mitigar fuerza bruta.
 
 ## Licencia
 

--- a/documentation.html
+++ b/documentation.html
@@ -152,6 +152,16 @@ python server/install_script.py</code></pre>
       <li>Tras finalizar, arranque el servidor:</li>
     </ol>
     <pre><button class="copy" data-copy="python server/Servidor/server.py">Copiar</button><code>python server/Servidor/server.py</code></pre>
+    <ol start="5">
+      <li>(Opcional) Construya el panel de administración si modificó la interfaz:</li>
+    </ol>
+    <pre><button class="copy" data-copy="cd server/admin-frontend\nnpm install\nnpm run build">Copiar</button><code>cd server/admin-frontend
+npm install
+npm run build</code></pre>
+    <ol start="6">
+      <li>Verifique el estado de la API:</li>
+    </ol>
+    <pre><button class="copy" data-copy="curl http://localhost:5000/api/status">Copiar</button><code>curl http://localhost:5000/api/status</code></pre>
 
     <h2 id="instalacion">Opciones de instalación</h2>
     <div class="tabs" data-tabs>
@@ -349,11 +359,18 @@ DATABASE_URL=sqlite:///bizon.db</code></pre>
     <p>Los roles <code>admin</code>, <code>operador</code> y <code>cliente</code> delimitan el acceso a módulos y endpoints.</p>
     <h3>Panel cliente</h3>
     <p>Tras autenticarse, los usuarios acceden al panel en <code>/cliente</code> para gestionar sus dispositivos.</p>
+    <h3>Ejemplo: listar dispositivos</h3>
+    <pre><code>curl -H "Authorization: Bearer &lt;token_cliente&gt;" https://mi-servidor/api/devices</code></pre>
+    <h3>Acciones sobre un dispositivo</h3>
+    <pre><code>curl -X POST https://mi-servidor/api/devices/42/lock \
+  -H "Authorization: Bearer &lt;token_cliente&gt;"</code></pre>
     <h3>Consideraciones de seguridad</h3>
     <ul>
       <li>Requiere HTTPS y tokens JWT válidos.</li>
       <li>Las contraseñas se guardan con hash seguro (bcrypt).</li>
       <li>Revoca tokens comprometidos y usa expiración corta.</li>
+      <li>Deshabilita el instalador <code>/install</code> tras la configuración.</li>
+      <li>Limita intentos de inicio de sesión para mitigar fuerza bruta.</li>
     </ul>
 
     <h2 id="seguridad">Seguridad</h2>


### PR DESCRIPTION
## Summary
- detail prerequisites and extended install steps
- document user creation, login, and client panel usage
- add endpoint call examples and security guidance

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68978de4ab9083208b43d684e1bb965e