### PR TITLE
Add public device registration endpoint

### DIFF
--- a/mobile/app/src/main/java/com/example/mdmjive/network/ApiService.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/network/ApiService.kt
@@ -16,6 +16,7 @@ import com.example.mdmjive.network.models.Command
 
 // Interface para los endpoints de la API
 interface ApiService {
+    // Endpoint público para registrar el dispositivo en el servidor
     @POST("devices/register")
     suspend fun registerDevice(@Body deviceInfo: DeviceInfo): Response<ApiResponse>
 

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -173,9 +173,7 @@ def get_provisioning_qr(device_id: str):
     buf.seek(0)
     return send_file(buf, mimetype='image/png')
 
-@app.route('/admin/devices/register', methods=['POST'])
-@require_admin
-def register_device():
+def _register_device():
     """Registra un dispositivo a partir de un JSON enviado por la app."""
     data = request.get_json() or {}
     device_id = data.get('deviceId')
@@ -203,6 +201,19 @@ def register_device():
         db.commit()
     logging.info('registro dispositivo %s', device_id)
     return jsonify({'success': True, 'message': 'Dispositivo registrado'}), 200
+
+
+@app.route('/admin/devices/register', methods=['POST'])
+@require_admin
+def register_device_admin():
+    """Endpoint protegido para registrar dispositivos."""
+    return _register_device()
+
+
+@app.route('/devices/register', methods=['POST'])
+def register_device_public():
+    """Endpoint público para registrar dispositivos."""
+    return _register_device()
 
 @app.route('/client/devices/status', methods=['POST'])
 @require_client

--- a/server/Servidor/tests/test_server.py
+++ b/server/Servidor/tests/test_server.py
@@ -131,7 +131,7 @@ class ServerTestCase(unittest.TestCase):
 
     def test_admin_clients_crud(self):
         # Register a device to assign later
-        self.client.post('/devices/register', json={'deviceId': 'd1'}, headers=self.auth_header())
+        self.client.post('/devices/register', json={'deviceId': 'd1'})
         resp = self.client.post(
             '/admin/clients',
             json={'username': 'cli', 'password': 'pwd', 'permissions': ['wipe']},


### PR DESCRIPTION
## Summary
- Expose new `/devices/register` route and reuse existing registration logic
- Document public registration endpoint in Android client
- Exercise public registration in admin clients CRUD test

## Testing
- `pytest server/Servidor/tests/test_server.py`

------
https://chatgpt.com/codex/tasks/task_b_689791797cb083208e412973b703c416