### PR TITLE
feat: hash admin passwords

### DIFF
--- a/server/Servidor/alembic/versions/0005_admin_password_hash.py
+++ b/server/Servidor/alembic/versions/0005_admin_password_hash.py
@@ -1,0 +1,32 @@
+"""rename password column to password_hash and hash existing passwords"""
+
+from alembic import op
+import sqlalchemy as sa
+import bcrypt
+
+# revision identifiers, used by Alembic.
+revision = '0005_admin_password_hash'
+down_revision = '0004_client_permissions'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('admins', sa.Column('password_hash', sa.String(), nullable=True))
+    conn = op.get_bind()
+    admins = conn.execute(sa.text('SELECT id, password FROM admins')).fetchall()
+    for admin in admins:
+        hashed = bcrypt.hashpw(admin.password.encode(), bcrypt.gensalt()).decode()
+        conn.execute(sa.text('UPDATE admins SET password_hash=:hash WHERE id=:id'), {'hash': hashed, 'id': admin.id})
+    op.drop_column('admins', 'password')
+    op.alter_column('admins', 'password_hash', nullable=False)
+
+
+def downgrade():
+    op.add_column('admins', sa.Column('password', sa.String(), nullable=True))
+    conn = op.get_bind()
+    admins = conn.execute(sa.text('SELECT id, password_hash FROM admins')).fetchall()
+    for admin in admins:
+        conn.execute(sa.text('UPDATE admins SET password=:hash WHERE id=:id'), {'hash': admin.password_hash, 'id': admin.id})
+    op.drop_column('admins', 'password_hash')
+    op.alter_column('admins', 'password', nullable=False)

--- a/server/Servidor/models.py
+++ b/server/Servidor/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import bcrypt
 from sqlalchemy import (
     Column,
     DateTime,
@@ -68,8 +69,14 @@ class Admin(Base):
     __tablename__ = "admins"
     id = Column(Integer, primary_key=True)
     username = Column(String, unique=True, nullable=False)
-    password = Column(String, nullable=False)
+    password_hash = Column(String, nullable=False)
     created = Column(DateTime(timezone=True), server_default=func.now())
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+    def check_password(self, password: str) -> bool:
+        return bcrypt.checkpw(password.encode(), self.password_hash.encode())
 
 
 class User(Base):

--- a/server/Servidor/requirements.txt
+++ b/server/Servidor/requirements.txt
@@ -3,3 +3,4 @@ qrcode
 SQLAlchemy>=2.0
 psycopg2-binary
 alembic
+bcrypt

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -136,7 +136,7 @@ def login():
     with get_session() as db:
         if username and password:
             admin = db.query(Admin).filter_by(username=username).first()
-            if admin and admin.password == password:
+            if admin and admin.check_password(password):
                 token = encode_jwt(username, JWT_SECRET, role='admin')
                 return jsonify({'token': token}), 200
         if client_id:

--- a/server/Servidor/tests/test_server.py
+++ b/server/Servidor/tests/test_server.py
@@ -37,7 +37,9 @@ class ServerTestCase(unittest.TestCase):
 
     def test_login(self):
         with get_session() as db:
-            db.add(Admin(username='adm', password='pwd'))
+            admin = Admin(username='adm')
+            admin.set_password('pwd')
+            db.add(admin)
             db.commit()
         resp = self.client.post('/login', json={'username': 'adm', 'password': 'pwd'})
         self.assertEqual(resp.status_code, 200)

--- a/server/install_script.py
+++ b/server/install_script.py
@@ -1,5 +1,5 @@
 import os
-import hashlib
+import bcrypt
 from flask import Flask, request, redirect, send_from_directory
 from Servidor.models import init_db, SessionLocal, Admin
 
@@ -24,8 +24,9 @@ def install():
         init_db()
         with SessionLocal() as session:
             if not session.query(Admin).filter_by(username=user).first():
-                hashed = hashlib.sha256(pwd.encode()).hexdigest()
-                session.add(Admin(username=user, password=hashed))
+                admin = Admin(username=user)
+                admin.set_password(pwd)
+                session.add(admin)
                 session.commit()
         return redirect('/admin/#/first-steps')
     root_dir = os.path.dirname(__file__)


### PR DESCRIPTION
## Summary
- secure admin passwords with bcrypt hashes and verification helpers
- migrate existing admin passwords to hashed format via Alembic revision
- update install script and tests for hashed authentication

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bcrypt')*


------
https://chatgpt.com/codex/tasks/task_b_6897929ea428832089146b573adec918