### PR TITLE
feat: control database reset

### DIFF
--- a/server/Servidor/install.py
+++ b/server/Servidor/install.py
@@ -34,7 +34,7 @@ def install():
             fh.write(fcm)
         os.environ['DATABASE_URL'] = db
         os.environ['JWT_SECRET'] = jwt
-        init_db()
+        init_db(drop=True)
         return redirect('/admin')
     return render_template_string(FORM)
 

--- a/server/Servidor/install_script.py
+++ b/server/Servidor/install_script.py
@@ -12,7 +12,7 @@ def install_application(db_host: str, db_name: str, db_user: str, db_pass: str, 
 
     os.environ['DATABASE_URL'] = db_url
     os.environ['JWT_SECRET'] = jwt_secret
-    init_db()
+    init_db(drop=True)
 
 
 if __name__ == '__main__':

--- a/server/Servidor/models.py
+++ b/server/Servidor/models.py
@@ -92,7 +92,16 @@ class Client(Base):
     devices = relationship("Device", secondary=client_devices, back_populates="clients")
 
 
-def init_db() -> None:
+def init_db(drop: bool = False) -> None:
+    """Inicializa la base de datos.
+
+    Por defecto solo aplica migraciones y crea las tablas si no existen. Si
+    ``drop`` es ``True`` o la variable de entorno ``TESTING`` está establecida
+    a un valor verdadero, se eliminan primero todas las tablas existentes.
+    """
+
+    should_drop = drop or os.getenv("TESTING", "").lower() in {"1", "true", "yes"}
+
     try:
         from alembic import command
         from alembic.config import Config
@@ -101,10 +110,12 @@ def init_db() -> None:
         cfg = Config(os.path.join(base_dir, "alembic.ini"))
         cfg.set_main_option("sqlalchemy.url", DB_URL)
         cfg.set_main_option("script_location", os.path.join(base_dir, "alembic"))
-        Base.metadata.drop_all(engine)
+        if should_drop:
+            Base.metadata.drop_all(engine)
         command.upgrade(cfg, "head")
         Base.metadata.create_all(engine)
     except (ModuleNotFoundError, ImportError):
         # Alembic no disponible: crea las tablas directamente
-        Base.metadata.drop_all(engine)
+        if should_drop:
+            Base.metadata.drop_all(engine)
         Base.metadata.create_all(engine)

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -632,7 +632,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.init_db:
-        init_db()
+        init_db(drop=True)
         print('Base de datos inicializada')
     else:
         host = os.getenv('BIZON_HOST', '0.0.0.0')

--- a/server/Servidor/tests/test_server.py
+++ b/server/Servidor/tests/test_server.py
@@ -21,7 +21,7 @@ class ServerTestCase(unittest.TestCase):
         os.unlink(DB_PATH)
 
     def setUp(self):
-        init_db()
+        init_db(drop=True)
         import werkzeug
         if not hasattr(werkzeug, "__version__"):
             werkzeug.__version__ = "3"
@@ -155,6 +155,18 @@ class ServerTestCase(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         resp = self.client.get('/admin/clients', headers=self.auth_header())
         self.assertEqual(resp.get_json(), [])
+
+    def test_init_db_preserves_data_without_drop_flag(self):
+        """Calling init_db without drop should not remove existing data."""
+        with get_session() as db:
+            db.add(Admin(username='keep', password='pwd'))
+            db.commit()
+
+        init_db()
+
+        with get_session() as db:
+            admin = db.query(Admin).filter_by(username='keep').first()
+            self.assertIsNotNone(admin)
 
 if __name__ == '__main__':
     unittest.main()

--- a/server/install_script.py
+++ b/server/install_script.py
@@ -21,7 +21,7 @@ def install():
 
         os.environ['DATABASE_URL'] = db
         os.environ['JWT_SECRET'] = jwt
-        init_db()
+        init_db(drop=True)
         with SessionLocal() as session:
             if not session.query(Admin).filter_by(username=user).first():
                 hashed = hashlib.sha256(pwd.encode()).hexdigest()


### PR DESCRIPTION
## Summary
- make `init_db` drop tables only when explicitly requested
- update server and install scripts to pass drop flag
- add regression test ensuring production data isn't removed

## Testing
- `cd server/Servidor && pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68979312b0ac8320b7225de4562177ae