### PR TITLE
Add unit and instrumented tests for core services

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -302,6 +302,7 @@ npm run build
       <li>Abra <code>app/</code> con Android Studio.</li>
       <li>Configure las constantes de servidor (ej.: <code>BASE_URL</code>) y FCM según el archivo de configuración del proyecto (por ejemplo, <code>BuildConfig</code> o recursos <code>strings.xml</code>).</li>
       <li>Conecte su proyecto Firebase y asegúrese de que el <em>Sender ID</em>/clave coincidan con el servidor.</li>
+      <li>Ejecute las pruebas con <code>./gradlew test connectedAndroidTest</code> para validar la aplicación.</li>
       <li>Construya e instale en el dispositivo (<code>Run ▶</code> o <code>Build APK</code>).</li>
     </ol>
 

--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -70,4 +70,21 @@ dependencies {
     // Firebase Cloud Messaging
     implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
     implementation("com.google.firebase:firebase-messaging")
+
+    // Unit testing
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:5.5.0")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("org.robolectric:robolectric:4.10.3")
+    testImplementation("androidx.test:core:1.5.0")
+
+    // Instrumented testing
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("org.mockito:mockito-android:5.5.0")
+    androidTestImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
+    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    androidTestImplementation("androidx.test:core:1.5.0")
+    androidTestImplementation("androidx.room:room-testing:2.6.1")
 }

--- a/mobile/app/src/androidTest/java/com/example/mdmjive/CommandReceptionInstrumentedTest.kt
+++ b/mobile/app/src/androidTest/java/com/example/mdmjive/CommandReceptionInstrumentedTest.kt
@@ -1,0 +1,42 @@
+package com.example.mdmjive
+
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.mdmjive.network.ApiService
+import com.example.mdmjive.network.models.Command
+import com.example.mdmjive.repository.DeviceRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import retrofit2.Response
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class CommandReceptionInstrumentedTest {
+    private lateinit var context: Context
+    private lateinit var api: ApiService
+    private lateinit var repository: DeviceRepository
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        Settings.Secure.putString(context.contentResolver, Settings.Secure.ANDROID_ID, "android-device")
+        api = mock()
+        val dao = mock<com.example.mdmjive.database.dao.DeviceDao>()
+        repository = DeviceRepository(api, dao)
+    }
+
+    @Test
+    fun fetchCommands_returnsListFromApi() = runBlocking {
+        whenever(api.getCommands("android-device")).thenReturn(Response.success(listOf(Command("LOCK"))))
+        val commands = repository.fetchCommands(context)
+        assertEquals(1, commands.size)
+        assertEquals("LOCK", commands[0].action)
+    }
+}
+

--- a/mobile/app/src/androidTest/java/com/example/mdmjive/DeviceRegistrationInstrumentedTest.kt
+++ b/mobile/app/src/androidTest/java/com/example/mdmjive/DeviceRegistrationInstrumentedTest.kt
@@ -1,0 +1,52 @@
+package com.example.mdmjive
+
+import android.content.Context
+import android.provider.Settings
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.mdmjive.database.LogDatabase
+import com.example.mdmjive.network.ApiService
+import com.example.mdmjive.network.models.ApiResponse
+import com.example.mdmjive.repository.DeviceRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import retrofit2.Response
+import kotlin.test.assertNotNull
+
+@RunWith(AndroidJUnit4::class)
+class DeviceRegistrationInstrumentedTest {
+    private lateinit var context: Context
+    private lateinit var db: LogDatabase
+    private lateinit var api: ApiService
+    private lateinit var repository: DeviceRepository
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        Settings.Secure.putString(context.contentResolver, Settings.Secure.ANDROID_ID, "android-device")
+        db = Room.inMemoryDatabaseBuilder(context, LogDatabase::class.java).build()
+        api = mock()
+        repository = DeviceRepository(api, db.deviceDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun registerDevice_insertsRecordInDatabase() = runBlocking {
+        whenever(api.registerDevice(any())).thenReturn(Response.success(ApiResponse(true)))
+        repository.registerDevice(context)
+        val stored = db.deviceDao().getDevice("android-device")
+        assertNotNull(stored)
+    }
+}
+

--- a/mobile/app/src/test/java/com/example/mdmjive/ApiServiceTest.kt
+++ b/mobile/app/src/test/java/com/example/mdmjive/ApiServiceTest.kt
@@ -1,0 +1,23 @@
+package com.example.mdmjive
+
+import com.example.mdmjive.network.ApiHandler
+import com.example.mdmjive.network.ApiResult
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.assertTrue
+import retrofit2.Response
+
+class ApiServiceTest {
+    @Test
+    fun safeApiCall_returnsSuccess() = runBlocking {
+        val result = ApiHandler.safeApiCall { Response.success("ok") }
+        assertTrue(result is ApiResult.Success && result.data == "ok")
+    }
+
+    @Test
+    fun safeApiCall_handlesException() = runBlocking {
+        val result = ApiHandler.safeApiCall<String> { throw RuntimeException("boom") }
+        assertTrue(result is ApiResult.Error)
+    }
+}
+

--- a/mobile/app/src/test/java/com/example/mdmjive/DeviceRepositoryTest.kt
+++ b/mobile/app/src/test/java/com/example/mdmjive/DeviceRepositoryTest.kt
@@ -1,0 +1,51 @@
+package com.example.mdmjive
+
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import com.example.mdmjive.database.dao.DeviceDao
+import com.example.mdmjive.network.ApiService
+import com.example.mdmjive.network.models.ApiResponse
+import com.example.mdmjive.network.models.Command
+import com.example.mdmjive.repository.DeviceRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.mockito.kotlin.*
+import retrofit2.Response
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class DeviceRepositoryTest {
+    private lateinit var apiService: ApiService
+    private lateinit var deviceDao: DeviceDao
+    private lateinit var repository: DeviceRepository
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        Settings.Secure.putString(context.contentResolver, Settings.Secure.ANDROID_ID, "test-device")
+        apiService = mock()
+        deviceDao = mock()
+        repository = DeviceRepository(apiService, deviceDao)
+    }
+
+    @Test
+    fun updateDeviceStatus_updatesDaoOnSuccess() = runBlocking {
+        whenever(apiService.updateStatus(any())).thenReturn(Response.success(ApiResponse(true)))
+        repository.updateDeviceStatus(context, "ACTIVE")
+        verify(deviceDao).updateDeviceStatus(eq("test-device"), eq("ACTIVE"), any())
+    }
+
+    @Test
+    fun fetchCommands_returnsCommandsFromApi() = runBlocking {
+        whenever(apiService.getCommands("test-device")).thenReturn(Response.success(listOf(Command("LOCK"))))
+        val result = repository.fetchCommands(context)
+        assertEquals(1, result.size)
+        assertEquals("LOCK", result.first().action)
+    }
+}
+

--- a/mobile/app/src/test/java/com/example/mdmjive/MDMServiceTest.kt
+++ b/mobile/app/src/test/java/com/example/mdmjive/MDMServiceTest.kt
@@ -1,0 +1,23 @@
+package com.example.mdmjive
+
+import android.app.Service
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.example.mdmjive.services.MDMService
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class MDMServiceTest {
+    @Test
+    fun onStartCommand_returnsStartSticky() {
+        val service = Robolectric.buildService(MDMService::class.java).create().get()
+        val intent = Intent(ApplicationProvider.getApplicationContext(), MDMService::class.java)
+        val result = service.onStartCommand(intent, 0, 0)
+        assertEquals(Service.START_STICKY, result)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for DeviceRepository, MDMService and ApiService
- create instrumented tests for device registration and command reception flows
- document how to run tests and include testing dependencies

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_689798f8906c83209505a06a38fea784