### PR TITLE
feat: configurable MDM service and foreground execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ BizonMDM es una plataforma de Mobile Device Management (MDM) de código abierto.
 ## Estructura del repositorio
 
 - `mobile/`: aplicación móvil Android.
+  - El servicio MDM se ejecuta como foreground y muestra una notificación persistente.
+  - La URL del servidor se configura mediante `BuildConfig.BASE_URL` en `mobile/app/build.gradle.kts`.
 - `server/`: archivos relacionados con el servidor y el panel de administración.
   - `Servidor/`: API en Flask, modelos de base de datos y scripts de instalación.
   - `admin-frontend/`: interfaz web de administración construida en React.

--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -15,6 +15,8 @@ android {
         versionCode = 1
         versionName = "1.0"
 
+        buildConfigField("String", "BASE_URL", "\"https://example.com/\"")
+
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments += mapOf(
@@ -42,6 +44,10 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/mobile/app/src/androidTest/java/com/example/mdmjive/MDMServiceForegroundInstrumentedTest.kt
+++ b/mobile/app/src/androidTest/java/com/example/mdmjive/MDMServiceForegroundInstrumentedTest.kt
@@ -1,0 +1,24 @@
+package com.example.mdmjive
+
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.mdmjive.services.MDMService
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class MDMServiceForegroundInstrumentedTest {
+    @Test
+    fun startingService_postsForegroundNotification() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        context.startForegroundService(Intent(context, MDMService::class.java))
+        Thread.sleep(1000)
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val active = manager.activeNotifications.any { it.id == MDMService.NOTIFICATION_ID }
+        assertTrue(active)
+    }
+}

--- a/mobile/app/src/main/java/com/example/mdmjive/MainActivity.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/MainActivity.kt
@@ -4,6 +4,7 @@ import android.app.admin.DevicePolicyManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -82,7 +83,11 @@ class MainActivity : ComponentActivity() {
     private fun startMDMService() {
         try {
             val serviceIntent = Intent(this, MDMService::class.java)
-            startService(serviceIntent)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                startForegroundService(serviceIntent)
+            } else {
+                startService(serviceIntent)
+            }
             Log.d("MDM", "Servicio MDM iniciado")
         } catch (e: Exception) {
             Log.e("MDM", "Error al iniciar servicio: ${e.message}")

--- a/mobile/app/src/main/java/com/example/mdmjive/services/MDMService.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/services/MDMService.kt
@@ -1,23 +1,34 @@
 package com.example.mdmjive.services
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
+import android.app.admin.DevicePolicyManager
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.IBinder
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
-import com.example.mdmjive.repository.DeviceRepository
-import com.example.mdmjive.network.ApiServiceFactory
+import com.example.mdmjive.BuildConfig
+import com.example.mdmjive.R
 import com.example.mdmjive.database.LogDatabase
+import com.example.mdmjive.network.ApiServiceFactory
+import com.example.mdmjive.repository.DeviceRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
-import android.app.admin.DevicePolicyManager
 
 class MDMService : Service() {
+
+    companion object {
+        const val CHANNEL_ID = "mdm_service"
+        const val NOTIFICATION_ID = 1
+    }
 
     private lateinit var devicePolicyManager: DevicePolicyManager
     private lateinit var repository: DeviceRepository
@@ -26,6 +37,14 @@ class MDMService : Service() {
 
     override fun onCreate() {
         super.onCreate()
+        createNotificationChannel()
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText(getString(R.string.mdm_service_running))
+            .setSmallIcon(android.R.drawable.ic_lock_idle_lock)
+            .setOngoing(true)
+            .build()
+        startForeground(NOTIFICATION_ID, notification)
         setupService()
     }
 
@@ -35,7 +54,7 @@ class MDMService : Service() {
         workManager = WorkManager.getInstance(applicationContext)
 
         // Inicializa el repositorio
-        val apiService = ApiServiceFactory.create("https://example.com/")
+        val apiService = ApiServiceFactory.create(BuildConfig.BASE_URL)
         val database = LogDatabase.getDatabase(applicationContext)
         repository = DeviceRepository(apiService, database.deviceDao())
 
@@ -48,6 +67,18 @@ class MDMService : Service() {
             } catch (e: Exception) {
                 Log.e("MDMService", "Error al registrar el dispositivo: ${e.message}")
             }
+        }
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.mdm_service_channel),
+                NotificationManager.IMPORTANCE_LOW
+            )
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
         }
     }
 

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="lock_device">Bloquear dispositivo</string>
     <string name="lock_message">Dispositivo bloqueado por BizonMDM</string>
     <string name="package_name_hint">Nombre del paquete</string>
+    <string name="mdm_service_channel">Servicio MDM</string>
+    <string name="mdm_service_running">Servicio MDM en ejecución</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow configuring MDM backend URL via `BuildConfig.BASE_URL`
- run `MDMService` as a foreground service with a persistent notification
- start service with `startForegroundService` from `MainActivity` and add instrumentation test

## Testing
- `gradle test` *(fails: SDK location not found)*
- `gradle connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68979b0e497883208765d14acd5ef029