### PR TITLE
Hash client passwords with bcrypt

### DIFF
--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -17,6 +17,7 @@ import hashlib
 import urllib.request
 import time
 from functools import wraps
+import bcrypt
 
 from models import Device, LogEntry, Command, SessionLocal, init_db, Admin, User, Client
 from sqlalchemy import text
@@ -592,7 +593,8 @@ def admin_clients():
     permissions = data.get('permissions', [])
     devices = data.get('devices', [])
     with get_session() as db:
-        user = User(username=username, password_hash=password, role='client')
+        hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+        user = User(username=username, password_hash=hashed, role='client')
         client = Client(user=user, permissions=json.dumps(permissions))
         for device_id in devices:
             device = db.query(Device).filter_by(device_id=device_id).first()

--- a/server/Servidor/tests/test_server.py
+++ b/server/Servidor/tests/test_server.py
@@ -4,6 +4,7 @@ import unittest
 import sys
 import time
 from unittest import mock
+import bcrypt
 
 # Configure database and token before importing the server
 DB_FD, DB_PATH = tempfile.mkstemp()
@@ -13,7 +14,7 @@ os.environ['SKIP_ALEMBIC'] = '1'
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from server import app, init_db, encode_jwt, decode_jwt, get_session
-from models import Admin
+from models import Admin, User
 
 
 class ServerTestCase(unittest.TestCase):
@@ -199,6 +200,11 @@ class ServerTestCase(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 201)
         cid = resp.get_json()['id']
+        with get_session() as db:
+            user = db.query(User).filter_by(username='cli').first()
+            self.assertIsNotNone(user)
+            self.assertNotEqual(user.password_hash, 'pwd')
+            self.assertTrue(bcrypt.checkpw('pwd'.encode(), user.password_hash.encode()))
         resp = self.client.get('/admin/clients', headers=self.auth_header())
         self.assertEqual(len(resp.get_json()), 1)
         resp = self.client.put(


### PR DESCRIPTION
## Summary
- Hash client passwords using bcrypt when creating clients
- Test client password hashing and verification with bcrypt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6897a13b4adc8320a73ec3ae10a9b67f