### PR TITLE
Add server setup script

### DIFF
--- a/server/setup.sh
+++ b/server/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Determine the directory containing this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Install Python dependencies
+pip install -r "$SCRIPT_DIR/Servidor/requirements.txt"
+
+# Run installation script (will prompt for configuration if needed)
+python "$SCRIPT_DIR/install_script.py"
+
+# Launch the server
+python "$SCRIPT_DIR/Servidor/server.py"


### PR DESCRIPTION
## Summary
- add setup.sh to install dependencies, run installation, and start server

## Testing
- `bash -n server/setup.sh`


------
https://chatgpt.com/codex/tasks/task_b_6897c50bea0c83209a66e3252d22173f