### PR TITLE
feat: add admin financial and audit modules

### DIFF
--- a/server/admin-frontend/admin/clients/index.jsx
+++ b/server/admin-frontend/admin/clients/index.jsx
@@ -1,0 +1,74 @@
+const { useState, useEffect } = React;
+
+const PERMISSIONS = ['dispositivos', 'contratos'];
+
+function StoreUserManager() {
+  const [stores, setStores] = useState([]);
+  const [storeName, setStoreName] = useState('');
+  const [users, setUsers] = useState([]);
+  const [username, setUsername] = useState('');
+  const [perms, setPerms] = useState([]);
+
+  useEffect(() => {
+    if (window.apiFetch) {
+      window.apiFetch('/api/stores').then(setStores).catch(() => setStores([]));
+      window.apiFetch('/api/users').then(setUsers).catch(() => setUsers([]));
+    }
+  }, []);
+
+  function createStore(e) {
+    e.preventDefault();
+    if (!window.apiFetch) return;
+    window.apiFetch('/api/stores', { method: 'POST', body: JSON.stringify({ name: storeName }) })
+      .then(s => setStores([...stores, s]))
+      .catch(() => {})
+      .finally(() => setStoreName(''));
+  }
+
+  function createUser(e) {
+    e.preventDefault();
+    if (!window.apiFetch) return;
+    const body = { username, permissions: perms };
+    window.apiFetch('/api/users', { method: 'POST', body: JSON.stringify(body) })
+      .then(u => setUsers([...users, u]))
+      .catch(() => {})
+      .finally(() => { setUsername(''); setPerms([]); });
+  }
+
+  const toggle = (p) => {
+    setPerms(perms.includes(p) ? perms.filter(x => x !== p) : [...perms, p]);
+  };
+
+  return (
+    <div>
+      <h2>Tiendas</h2>
+      <form onSubmit={createStore} style={{ marginBottom: '1rem' }}>
+        <input value={storeName} onChange={e => setStoreName(e.target.value)} placeholder="Nombre" />
+        <button type="submit">Agregar</button>
+      </form>
+      <ul>
+        {stores.map(s => <li key={s.id}>{s.name}</li>)}
+      </ul>
+
+      <h2>Usuarios</h2>
+      <form onSubmit={createUser} style={{ marginBottom: '1rem' }}>
+        <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Usuario" />
+        <div>
+          {PERMISSIONS.map(p => (
+            <label key={p} style={{ marginRight: '0.5rem' }}>
+              <input type="checkbox" checked={perms.includes(p)} onChange={() => toggle(p)} /> {p}
+            </label>
+          ))}
+        </div>
+        <button type="submit">Crear</button>
+      </form>
+      <ul>
+        {users.map(u => (
+          <li key={u.id}>{u.username} - {u.permissions.join(', ')}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+window.StoreUserManager = StoreUserManager;

--- a/server/admin-frontend/admin/dashboard/index.jsx
+++ b/server/admin-frontend/admin/dashboard/index.jsx
@@ -1,0 +1,26 @@
+const { useState, useEffect } = React;
+
+function FinancialDashboard() {
+  const [data, setData] = useState({});
+
+  useEffect(() => {
+    if (window.apiFetch) {
+      window.apiFetch('/api/finance')
+        .then(setData)
+        .catch(() => setData({}));
+    }
+  }, []);
+
+  return (
+    <div>
+      <h2>Indicadores financieros</h2>
+      <ul>
+        <li>Ingresos: {data.revenue ?? 'N/D'}</li>
+        <li>Gastos: {data.expenses ?? 'N/D'}</li>
+        <li>Beneficio: {data.profit ?? 'N/D'}</li>
+      </ul>
+    </div>
+  );
+}
+
+window.FinancialDashboard = FinancialDashboard;

--- a/server/admin-frontend/admin/logs/index.jsx
+++ b/server/admin-frontend/admin/logs/index.jsx
@@ -1,0 +1,39 @@
+const { useState, useEffect } = React;
+
+function AuditLogs() {
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    if (window.apiFetch) {
+      window.apiFetch('/api/logs')
+        .then(d => setLogs(d.logs || []))
+        .catch(() => setLogs([]));
+    }
+  }, []);
+
+  return (
+    <div>
+      <h2>Auditoría</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Fecha</th>
+            <th>Acción</th>
+            <th>Usuario</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((l, i) => (
+            <tr key={i}>
+              <td>{l.date || '-'}</td>
+              <td>{l.action}</td>
+              <td>{l.user || '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+window.AuditLogs = AuditLogs;

--- a/server/admin-frontend/app.jsx
+++ b/server/admin-frontend/app.jsx
@@ -13,6 +13,8 @@ async function apiFetch(path, options = {}) {
   if (!res.ok) throw new Error('API error');
   return res.json();
 }
+// Expose helper for other modules
+window.apiFetch = apiFetch;
 
 function ServerStatus() {
   const [status, setStatus] = useState(null);
@@ -385,12 +387,15 @@ function App() {
 
   let page;
   if (route === '#/dashboard') page = <Dashboard />;
+  else if (route === '#/dashboard/finance') page = <FinancialDashboard />;
   else if (route === '#/devices') page = <DeviceTable onSelect={(id) => window.location.hash = `#/devices/${id}`} />;
   else if (route.startsWith('#/devices/')) {
     const id = route.split('/')[2];
     page = <DeviceDetails id={id} onBack={() => window.location.hash = '#/devices'} />;
   } else if (route === '#/policies') page = <PolicyEditor />;
   else if (route === '#/clients') page = <ClientManager />;
+  else if (route === '#/admin/clients') page = <StoreUserManager />;
+  else if (route === '#/admin/logs') page = <AuditLogs />;
   else if (route === '#/config') page = <Config />;
   else if (route === '#/first-steps') page = <FirstSteps />;
   else page = <Dashboard />;
@@ -401,9 +406,12 @@ function App() {
         <h1>{tenantConfig.title || 'Bizon MDM Admin'}</h1>
         <nav>
           <a href="#/dashboard">Dashboard</a>
+          <a href="#/dashboard/finance">Finanzas</a>
           <a href="#/devices">Dispositivos</a>
           <a href="#/policies">Políticas</a>
           <a href="#/clients">Clientes</a>
+          <a href="#/admin/clients">Tiendas y usuarios</a>
+          <a href="#/admin/logs">Logs</a>
           <a href="#/config">Config</a>
         </nav>
         <ServerStatus />

--- a/server/admin-frontend/index.html
+++ b/server/admin-frontend/index.html
@@ -18,7 +18,10 @@
   <div id="root"></div>
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
-  <script type="text/babel" src="app.jsx"></script>
-</body>
-</html>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script type="text/babel" src="admin/dashboard/index.jsx"></script>
+    <script type="text/babel" src="admin/clients/index.jsx"></script>
+    <script type="text/babel" src="admin/logs/index.jsx"></script>
+    <script type="text/babel" src="app.jsx"></script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- add financial dashboard component for admin area
- add store and user management with permissions
- add audit log viewer and navigation links

## Testing
- `cd server/admin-frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_6897cc7685388320b8e11bd3c1f43f30