### PR TITLE
feat: add document upload and review modules

### DIFF
--- a/admin/documents/__init__.py
+++ b/admin/documents/__init__.py
@@ -1,0 +1,1 @@
+"""Gestión administrativa de documentos."""

--- a/admin/documents/review.py
+++ b/admin/documents/review.py
@@ -1,0 +1,41 @@
+"""Proceso de revisión y aprobación de documentos."""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+
+from documents.storage import list_pending, set_status
+
+bp = Blueprint("document_review", __name__, url_prefix="/documents")
+
+
+@bp.route("/pending", methods=["GET"])
+def pending():
+    """Lista los documentos que aún no han sido revisados."""
+
+    docs = [
+        {"id": d.id, "filename": d.filename, "status": d.status}
+        for d in list_pending()
+    ]
+    return jsonify({"pending": docs})
+
+
+@bp.route("/approve/<doc_id>", methods=["POST"])
+def approve(doc_id: str):
+    """Aprueba un documento."""
+
+    if not set_status(doc_id, "approved"):
+        return jsonify({"success": False, "message": "No encontrado"}), 404
+    return jsonify({"success": True})
+
+
+@bp.route("/reject/<doc_id>", methods=["POST"])
+def reject(doc_id: str):
+    """Rechaza un documento."""
+
+    if not set_status(doc_id, "rejected"):
+        return jsonify({"success": False, "message": "No encontrado"}), 404
+    return jsonify({"success": True})
+
+
+__all__ = ["bp"]

--- a/client/documents/__init__.py
+++ b/client/documents/__init__.py
@@ -1,0 +1,1 @@
+"""Vistas de documentos del cliente."""

--- a/client/documents/views.py
+++ b/client/documents/views.py
@@ -1,0 +1,37 @@
+"""Vistas para gestión de documentos por parte del cliente.
+
+Proporciona un formulario para subir archivos y un endpoint para consultar el
+estado de revisión del documento cargado.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from documents.storage import get, save
+
+bp = Blueprint("client_documents", __name__, url_prefix="/documents")
+
+
+@bp.route("/upload", methods=["POST"])
+def upload():
+    """Recibe un archivo y lo almacena."""
+
+    file = request.files.get("file")
+    if not file or file.filename == "":
+        return jsonify({"success": False, "message": "Archivo requerido"}), 400
+    doc = save(file)
+    return jsonify({"success": True, "document_id": doc.id}), 201
+
+
+@bp.route("/status/<doc_id>", methods=["GET"])
+def status(doc_id: str):
+    """Devuelve el estado actual de un documento."""
+
+    doc = get(doc_id)
+    if not doc:
+        return jsonify({"success": False, "message": "No encontrado"}), 404
+    return jsonify({"id": doc.id, "filename": doc.filename, "status": doc.status})
+
+
+__all__ = ["bp"]

--- a/documents/__init__.py
+++ b/documents/__init__.py
@@ -1,0 +1,3 @@
+"""Módulo de documentos para la plataforma BizonMDM."""
+
+# El paquete expone funcionalidad para almacenamiento y gestión de archivos.

--- a/documents/storage/__init__.py
+++ b/documents/storage/__init__.py
@@ -1,0 +1,68 @@
+"""Almacenamiento simple de documentos con metadatos."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+import uuid
+
+
+@dataclass
+class Document:
+    """Representa un documento cargado por un usuario."""
+
+    id: str
+    filename: str
+    content_type: str
+    path: Path
+    status: str = "pending"  # pending, approved, rejected
+
+
+_STORAGE_DIR = Path(__file__).resolve().parent / "files"
+_METADATA: Dict[str, Document] = {}
+
+# Nos aseguramos de que exista el directorio físico donde guardar los archivos.
+_STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def save(file) -> Document:
+    """Guarda un archivo y almacena sus metadatos."""
+
+    doc_id = str(uuid.uuid4())
+    filename = file.filename
+    path = _STORAGE_DIR / f"{doc_id}_{filename}"
+    file.save(path)
+    doc = Document(id=doc_id, filename=filename, content_type=file.mimetype, path=path)
+    _METADATA[doc_id] = doc
+    return doc
+
+
+def get(doc_id: str) -> Optional[Document]:
+    """Recupera un documento por su identificador."""
+
+    return _METADATA.get(doc_id)
+
+
+def list_pending() -> List[Document]:
+    """Lista los documentos pendientes de revisión."""
+
+    return [d for d in _METADATA.values() if d.status == "pending"]
+
+
+def set_status(doc_id: str, status: str) -> bool:
+    """Actualiza el estado de un documento."""
+
+    if doc_id in _METADATA:
+        _METADATA[doc_id].status = status
+        return True
+    return False
+
+
+__all__ = [
+    "Document",
+    "save",
+    "get",
+    "list_pending",
+    "set_status",
+]

--- a/documents/storage/files/.gitignore
+++ b/documents/storage/files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- add document storage with metadata handling
- implement client views for document upload and status tracking
- create admin review endpoints to approve or reject documents

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6897f738a5d88320a022654d960b2f31