### PR TITLE
feat: enforce store context for clients

### DIFF
--- a/client/contracts/views.py
+++ b/client/contracts/views.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from flask import Blueprint, jsonify, request
 
 from financing.contracts.models import Contract, PaymentSchedule, SessionLocal
+from server.Servidor.models import SessionLocal as MainSession, Client
 
 
 bp = Blueprint("contracts", __name__, url_prefix="/contracts")
@@ -15,11 +16,16 @@ def register_contract():
 
     data = request.get_json() or {}
     client_id = data.get("client_id")
+    store_id = data.get("store_id")
     amount = data.get("amount")
     interest_rate = data.get("interest_rate")
     term = data.get("term")
-    if not all([client_id, amount, interest_rate, term]):
+    if not all([client_id, amount, interest_rate, term, store_id]):
         return jsonify({"success": False, "message": "Campos incompletos"}), 400
+    with MainSession() as mdb:
+        client = mdb.query(Client).filter_by(id=client_id, store_id=store_id).first()
+        if not client:
+            return jsonify({"success": False, "message": "Cliente no encontrado"}), 404
 
     with SessionLocal() as db:
         contract = Contract(
@@ -52,6 +58,13 @@ def register_contract():
 def pending_payments(client_id: int):
     """Lista los pagos pendientes de un cliente."""
 
+    store_id = request.args.get("store_id", type=int)
+    if store_id is None:
+        return jsonify({"success": False, "message": "store_id requerido"}), 400
+    with MainSession() as mdb:
+        client = mdb.query(Client).filter_by(id=client_id, store_id=store_id).first()
+        if not client:
+            return jsonify({"pending": []})
     with SessionLocal() as db:
         schedules = (
             db.query(PaymentSchedule)

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -102,8 +102,9 @@ def decode_jwt(token: str, secret: str) -> dict:
             raise ValueError("Missing claim")
     if int(payload["exp"]) < int(time.time()):
         raise ValueError("Token expired")
-    if payload["role"] == "client" and not payload.get("client_id"):
-        raise ValueError("Missing client_id")
+    if payload["role"] == "client":
+        if not payload.get("client_id") or not payload.get("store_id"):
+            raise ValueError("Missing client_id or store_id")
     if payload["role"] == "user" and not payload.get("store_id"):
         raise ValueError("Missing store_id")
     return payload
@@ -150,7 +151,12 @@ def require_client(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         auth = require_auth(request)
-        if not auth or auth.get('role') != 'client' or not auth.get('client_id'):
+        if (
+            not auth
+            or auth.get('role') != 'client'
+            or not auth.get('client_id')
+            or not auth.get('store_id')
+        ):
             return jsonify({'success': False, 'message': 'Unauthorized'}), 401
         return func(*args, auth=auth, **kwargs)
 
@@ -259,8 +265,15 @@ def login():
                 return jsonify({'token': token}), 200
         if client_id:
             device = db.query(Device).filter_by(device_id=client_id).first()
-            if device:
-                token = encode_jwt(client_id, JWT_SECRET, role='client', client_id=client_id)
+            if device and device.clients:
+                store_id = device.clients[0].store_id
+                token = encode_jwt(
+                    client_id,
+                    JWT_SECRET,
+                    role='client',
+                    client_id=client_id,
+                    store_id=store_id,
+                )
                 return jsonify({'token': token}), 200
     return jsonify({'success': False, 'message': 'Invalid credentials'}), 401
 
@@ -342,7 +355,12 @@ def update_status(auth):
     if device_id != auth.get('client_id'):
         return jsonify({'success': False, 'message': 'Unauthorized'}), 401
     with get_session() as db:
-        device = db.query(Device).filter_by(device_id=device_id).first()
+        device = (
+            db.query(Device)
+            .join(Device.clients)
+            .filter(Device.device_id == device_id, Client.store_id == auth.get('store_id'))
+            .first()
+        )
         if not device:
             return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
         device.status = json.dumps(data)
@@ -400,7 +418,12 @@ def get_own_device(auth):
     """Devuelve la información del dispositivo asociado al cliente."""
     device_id = auth.get('client_id')
     with get_session() as db:
-        device = db.query(Device).filter_by(device_id=device_id).first()
+        device = (
+            db.query(Device)
+            .join(Device.clients)
+            .filter(Device.device_id == device_id, Client.store_id == auth.get('store_id'))
+            .first()
+        )
         if not device:
             return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
         info = json.loads(device.info or '{}')
@@ -428,7 +451,12 @@ def upload_logs(auth):
     logs = data.get('logs', [])
     device_id = auth.get('client_id')
     with get_session() as db:
-        device = db.query(Device).filter_by(device_id=device_id).first()
+        device = (
+            db.query(Device)
+            .join(Device.clients)
+            .filter(Device.device_id == device_id, Client.store_id == auth.get('store_id'))
+            .first()
+        )
         if not device:
             return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
         if isinstance(logs, list):
@@ -650,7 +678,12 @@ def add_command():
 def get_client_commands(auth):
     device_id = auth.get('client_id')
     with get_session() as db:
-        device = db.query(Device).filter_by(device_id=device_id).first()
+        device = (
+            db.query(Device)
+            .join(Device.clients)
+            .filter(Device.device_id == device_id, Client.store_id == auth.get('store_id'))
+            .first()
+        )
         if not device:
             return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
         cmds = [json.loads(c.command) for c in device.commands]

--- a/server/Servidor/tests/test_server.py
+++ b/server/Servidor/tests/test_server.py
@@ -13,7 +13,7 @@ os.environ['SKIP_ALEMBIC'] = '1'
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from server import app, init_db, encode_jwt, decode_jwt, get_session
-from models import Admin
+from models import Admin, Device, Client, User, Store
 
 
 class ServerTestCase(unittest.TestCase):
@@ -29,12 +29,43 @@ class ServerTestCase(unittest.TestCase):
             werkzeug.__version__ = "3"
         self.client = app.test_client()
         self.token = encode_jwt('tester', os.environ['JWT_SECRET'], role='admin')
+        with get_session() as db:
+            store = Store(name='S1')
+            db.add(store)
+            db.commit()
+            self.store_id = store.id
 
     def auth_header(self):
         return {'Authorization': f'Bearer {self.token}'}
 
     def client_header(self, device_id='d1'):
-        token = encode_jwt(device_id, os.environ['JWT_SECRET'], role='client', client_id=device_id)
+        with get_session() as db:
+            store = db.query(Store).first()
+            device = db.query(Device).filter_by(device_id=device_id).first()
+            if not device:
+                device = Device(device_id=device_id)
+                db.add(device)
+                db.flush()
+            client = (
+                db.query(Client)
+                .join(Client.devices)
+                .filter(Device.device_id == device_id)
+                .first()
+            )
+            if not client:
+                user = User(username=f'u_{device_id}', role='client', store_id=store.id)
+                user.set_password('pwd')
+                client = Client(user=user, store_id=store.id)
+                client.devices.append(device)
+                db.add(client)
+            db.commit()
+            token = encode_jwt(
+                device_id,
+                os.environ['JWT_SECRET'],
+                role='client',
+                client_id=device_id,
+                store_id=store.id,
+            )
         return {'Authorization': f'Bearer {token}'}
 
     def test_login(self):
@@ -52,12 +83,15 @@ class ServerTestCase(unittest.TestCase):
 
         # Login as client using an existing device
         self.client.post('/admin/devices/register', json={'deviceId': 'd1'}, headers=self.auth_header())
+        # ensure client association and token creation side-effect
+        self.client_header('d1')
         resp = self.client.post('/login', json={'client_id': 'd1'})
         self.assertEqual(resp.status_code, 200)
         token = resp.get_json()['token']
         payload = decode_jwt(token, os.environ['JWT_SECRET'])
         self.assertEqual(payload['role'], 'client')
         self.assertEqual(payload['client_id'], 'd1')
+        self.assertEqual(payload['store_id'], self.store_id)
 
     def test_expired_token(self):
         expired = encode_jwt('tester', os.environ['JWT_SECRET'], role='admin', expires_in=-1)


### PR DESCRIPTION
## Summary
- require client JWTs to include a store id and validate it in `require_client`
- scope `/client/*` device and contract endpoints to the authenticated store
- include store id in client login tokens and test coverage

## Testing
- `pytest server/Servidor/tests/test_server.py`

------
https://chatgpt.com/codex/tasks/task_b_6897fb6e9d848320a94d5923c9078fc0