### PR TITLE
Add Timber logging dependency

### DIFF
--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -77,6 +77,9 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
     implementation("com.google.firebase:firebase-messaging")
 
+    // Logging
+    implementation("com.jakewharton.timber:timber:5.0.1")
+
     // Unit testing
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.5.0")


### PR DESCRIPTION
## Summary
- add Timber logging library to Android app module

## Testing
- `./gradlew app:assembleDebug` *(fails: Unable to tunnel through proxy; HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6897fff93f5483209687e0194a05cb04