### PR TITLE
chore: add WorkManager runtime dependency

### DIFF
--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -69,6 +69,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
 
+    // WorkManager
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
+
     // Networking
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")


### PR DESCRIPTION
## Summary
- add AndroidX WorkManager runtime dependency
- confirm WorkManager classes are imported in service and worker

## Testing
- `gradle app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_689800f74f7c83208d21ac427ebd9996