### PR TITLE
Use BuildConfig base URL in API service creation

### DIFF
--- a/mobile/app/src/main/java/com/example/mdmjive/monitoring/LogManager.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/monitoring/LogManager.kt
@@ -1,6 +1,7 @@
 package com.example.mdmjive.monitoring
 
 import android.util.Log
+import com.example.mdmjive.BuildConfig
 import com.example.mdmjive.database.LogDatabase
 import com.example.mdmjive.database.entities.LogEntry
 import com.example.mdmjive.network.ApiServiceFactory
@@ -12,7 +13,7 @@ import kotlinx.coroutines.launch
 
 class LogManager(private val logDatabase: LogDatabase) {
 
-    private val apiService = ApiServiceFactory.create("https://example.com/")
+    private val apiService = ApiServiceFactory.create(BuildConfig.BASE_URL)
 
     // Función para registrar un evento en los logs
     fun logEvent(event: MDMEvent, deviceId: String = "unknown") {

--- a/mobile/app/src/main/java/com/example/mdmjive/services/FCMService.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/services/FCMService.kt
@@ -3,6 +3,7 @@ package com.example.mdmjive.services
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import android.util.Log
+import com.example.mdmjive.BuildConfig
 import com.example.mdmjive.repository.DeviceRepository
 import com.example.mdmjive.network.ApiServiceFactory
 import com.example.mdmjive.database.LogDatabase
@@ -21,7 +22,7 @@ class FCMService : FirebaseMessagingService() {
         super.onMessageReceived(message)
         CoroutineScope(Dispatchers.IO).launch {
             val repository = DeviceRepository(
-                ApiServiceFactory.create("https://example.com/"),
+                ApiServiceFactory.create(BuildConfig.BASE_URL),
                 LogDatabase.getDatabase(applicationContext).deviceDao()
             )
             val commands = repository.fetchCommands(applicationContext)

--- a/mobile/app/src/main/java/com/example/mdmjive/workers/SyncWorker.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/workers/SyncWorker.kt
@@ -1,14 +1,15 @@
 package com.example.mdmjive.workers
 
 import android.content.Context
+import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import android.util.Log
-import com.example.mdmjive.network.ApiServiceFactory
+import com.example.mdmjive.BuildConfig
+import com.example.mdmjive.controls.CommandExecutor
 import com.example.mdmjive.database.LogDatabase
+import com.example.mdmjive.network.ApiServiceFactory
 import com.example.mdmjive.repository.DeviceRepository
 import kotlinx.coroutines.Dispatchers
-import com.example.mdmjive.controls.CommandExecutor
 
 class SyncWorker(
     context: Context,
@@ -17,7 +18,7 @@ class SyncWorker(
 
     private val TAG = "SyncWorker"
     private val deviceRepository: DeviceRepository = DeviceRepository(
-        ApiServiceFactory.create("https://example.com/"),
+        ApiServiceFactory.create(BuildConfig.BASE_URL),
         LogDatabase.getDatabase(context).deviceDao()
     )
 


### PR DESCRIPTION
## Summary
- Replace hardcoded API base URLs with `BuildConfig.BASE_URL` when creating `ApiService`
- Confirm `BASE_URL` field defined in app BuildConfig

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_689801e4968c8320a822454f5e06e597