### PR TITLE
Register MDM application class

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
     <application
+        android:name=".MDMApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/mobile/app/src/main/java/com/example/mdmjive/MDMApplication.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/MDMApplication.kt
@@ -1,3 +1,5 @@
+package com.example.mdmjive
+
 import android.app.Application
 import com.example.mdmjive.database.LogDatabase
 import timber.log.Timber


### PR DESCRIPTION
## Summary
- declare `com.example.mdmjive` package in `MDMApplication` class
- register `MDMApplication` with the Android manifest

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_6898032e5c4883208f17fcd6c8a90dc2