### PR TITLE
Use visible theme for app

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -18,7 +18,9 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@android:style/Theme.NoDisplay">
+        android:theme="@style/Theme.AppCompat.Light">
+
+        <!-- Para ocultar la app tras la activación, controlar la visibilidad mediante políticas o hideLauncherIcon -->
 
         <!-- Receptor de administración -->
         <receiver


### PR DESCRIPTION
## Summary
- show app by using a visible AppCompat theme
- document how to hide the app after activation

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_b_6898032d2f448320afa4a61c9050ba43