### PR TITLE
Implement FRP policy and document account setup

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -304,6 +304,12 @@ npm run build
       <li>Conecte su proyecto Firebase y asegúrese de que el <em>Sender ID</em>/clave coincidan con el servidor.</li>
       <li>Ejecute las pruebas con <code>./gradlew test connectedAndroidTest</code> para validar la aplicación.</li>
       <li>Construya e instale en el dispositivo (<code>Run ▶</code> o <code>Build APK</code>).</li>
+      <li>Añada la cuenta Google permitida para la protección de restablecimiento de fábrica antes de bloquear la configuración del usuario:
+        <ol>
+          <li>En el dispositivo vaya a <strong>Ajustes › Cuentas › Agregar cuenta › Google</strong>.</li>
+          <li>Inicie sesión con <code>admin@tu-dominio.com</code> u otra cuenta autorizada.</li>
+        </ol>
+      </li>
     </ol>
 
     <h2 id="notificaciones">Notificaciones (Firebase Cloud Messaging)</h2>

--- a/mobile/app/src/main/java/com/example/mdmjive/receivers/MDMDeviceAdminReceiver.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/receivers/MDMDeviceAdminReceiver.kt
@@ -2,11 +2,13 @@ package com.example.mdmjive.receivers
 
 import android.app.admin.DeviceAdminReceiver
 import android.app.admin.DevicePolicyManager
+import android.app.admin.FactoryResetProtectionPolicy
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.content.pm.PackageManager
+import android.accounts.AccountManager
 import com.example.mdmjive.MainActivity
 import android.util.Log
 import com.example.mdmjive.security.PolicyManager
@@ -51,11 +53,28 @@ class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
                 // Bloquear la desinstalación de la propia app
                 setUninstallBlocked(componentName, packageName, true)
             }
+            val frpPolicy = FactoryResetProtectionPolicy.Builder()
+                .addAccount("admin@tu-dominio.com")
+                .build()
+            dpm.setFactoryResetProtectionPolicy(componentName, frpPolicy)
+
             val policyManager = PolicyManager(context)
-            policyManager.disableFactoryReset()
-            policyManager.lockBrightness()
-            policyManager.lockGPS()
-            policyManager.lockDateTime()
+            val accountManager = AccountManager.get(context)
+            val hasFrpAccount = accountManager
+                .getAccountsByType("com.google")
+                .any { it.name == "admin@tu-dominio.com" }
+
+            if (hasFrpAccount) {
+                policyManager.disableFactoryReset()
+                policyManager.lockBrightness()
+                policyManager.lockGPS()
+                policyManager.lockDateTime()
+            } else {
+                Log.w(
+                    "MDM",
+                    "Agregue la cuenta admin@tu-dominio.com antes de bloquear la configuración del usuario."
+                )
+            }
             Log.d("MDM", "Políticas aplicadas correctamente.")
         } catch (e: Exception) {
             Log.e("MDM", "Error aplicando políticas: ${e.message}")


### PR DESCRIPTION
## Summary
- Apply Factory Reset Protection policy with allowed Google account in DeviceAdminReceiver
- Warn if required account isn't present before locking user configuration
- Document how to add the FRP account on the device

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_689809323a0083208afc669a71d42168