### PR TITLE
Disable safe boot via DevicePolicyManager

### DIFF
--- a/mobile/app/src/main/java/com/example/mdmjive/receivers/MDMDeviceAdminReceiver.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/receivers/MDMDeviceAdminReceiver.kt
@@ -56,6 +56,7 @@ class MDMDeviceAdminReceiver : DeviceAdminReceiver() {
             policyManager.lockBrightness()
             policyManager.lockGPS()
             policyManager.lockDateTime()
+            policyManager.disableSafeBoot()
             Log.d("MDM", "Políticas aplicadas correctamente.")
         } catch (e: Exception) {
             Log.e("MDM", "Error aplicando políticas: ${e.message}")

--- a/mobile/app/src/main/java/com/example/mdmjive/security/PolicyManager.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/security/PolicyManager.kt
@@ -4,6 +4,7 @@ import android.app.admin.DevicePolicyManager
 import android.content.Context
 import android.content.ComponentName
 import android.util.Log
+import android.os.UserManager
 
 class PolicyManager(private val context: Context) {
     private val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
@@ -67,6 +68,15 @@ class PolicyManager(private val context: Context) {
             Log.d("MDM", "Restablecimiento de fábrica deshabilitado")
         } catch (e: Exception) {
             Log.e("MDM", "Error deshabilitando restablecimiento: ${e.message}")
+        }
+    }
+
+    fun disableSafeBoot() {
+        try {
+            dpm.addUserRestriction(componentName, UserManager.DISALLOW_SAFE_BOOT)
+            Log.d("MDM", "Modo seguro deshabilitado")
+        } catch (e: Exception) {
+            Log.e("MDM", "Error deshabilitando modo seguro: ${e.message}")
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent safe boot by adding DISALLOW_SAFE_BOOT user restriction
- expose disableSafeBoot policy helper and invoke from device admin receiver

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6898093e4e9883209d4c8bdd3da9fb57