### PR TITLE
feat: report device integrity details

### DIFF
--- a/mobile/app/src/main/java/com/example/mdmjive/network/models/DeviceStatus.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/network/models/DeviceStatus.kt
@@ -3,5 +3,8 @@ package com.example.mdmjive.network.models
 data class DeviceStatus(
     val deviceId: String,
     val status: String,
-    val lastUpdate: Long = System.currentTimeMillis()
+    val lastSync: Long = System.currentTimeMillis(),
+    val rootAttempt: Boolean = false,
+    val emulator: Boolean = false,
+    val unknownSources: Boolean = false
 )

--- a/mobile/app/src/main/java/com/example/mdmjive/security/DeviceCertificationManager.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/security/DeviceCertificationManager.kt
@@ -8,13 +8,35 @@ data class DeviceIntegrityResult(
 )
 
 import android.content.Context
+import android.provider.Settings
+import android.util.Log
+import com.example.mdmjive.network.ApiService
+import com.example.mdmjive.network.models.DeviceStatus
+import kotlinx.coroutines.runBlocking
 
-class DeviceCertificationManager(private val context: Context) {
+class DeviceCertificationManager(
+    private val context: Context,
+    private val apiService: ApiService
+) {
     fun validateDeviceIntegrity(): DeviceIntegrityResult {
         val isRooted = SecurityChecker.isDeviceRooted()
         val isEmulator = SecurityChecker.isRunningOnEmulator()
         val hasUnknownSources = SecurityChecker.hasUnknownSources(context)
         val integrityScore = calculateIntegrityScore(isRooted, isEmulator, hasUnknownSources)
+
+        val statusValue = if (isRooted || isEmulator || hasUnknownSources) "COMPROMISED" else "OK"
+        val deviceStatus = DeviceStatus(
+            deviceId = getDeviceId(),
+            status = statusValue,
+            rootAttempt = isRooted,
+            emulator = isEmulator,
+            unknownSources = hasUnknownSources
+        )
+        try {
+            runBlocking { apiService.updateStatus(deviceStatus) }
+        } catch (e: Exception) {
+            Log.e("DeviceCertificationManager", "Failed to update status", e)
+        }
 
         return DeviceIntegrityResult(
             isRooted = isRooted,
@@ -24,7 +46,11 @@ class DeviceCertificationManager(private val context: Context) {
         )
     }
 
-    private fun calculateIntegrityScore(isRooted: Boolean, isEmulator: Boolean, hasUnknownSources: Boolean): Int {
+    private fun calculateIntegrityScore(
+        isRooted: Boolean,
+        isEmulator: Boolean,
+        hasUnknownSources: Boolean
+    ): Int {
         var score = 100
 
         if (isRooted) score -= 40
@@ -33,4 +59,7 @@ class DeviceCertificationManager(private val context: Context) {
 
         return score.coerceAtLeast(0) // Asegura que el puntaje no sea negativo
     }
+
+    private fun getDeviceId(): String =
+        Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
 }

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -363,7 +363,18 @@ def update_status(auth):
         )
         if not device:
             return jsonify({'success': False, 'message': 'Dispositivo no encontrado'}), 404
-        device.status = json.dumps(data)
+        status = json.loads(device.status or '{}')
+        for field in (
+            'status',
+            'rootAttempt',
+            'emulator',
+            'unknownSources',
+            'lastSync',
+            'battery',
+        ):
+            if field in data:
+                status[field] = data[field]
+        device.status = json.dumps(status)
         if data.get('fcmToken'):
             device.fcm_token = data.get('fcmToken')
         db.commit()

--- a/server/admin-frontend/app.jsx
+++ b/server/admin-frontend/app.jsx
@@ -99,7 +99,10 @@ function DeviceTable({ onSelect }) {
               <td>{d.imei}</td>
               <td>{d.model}</td>
               <td>{d.serial}</td>
-              <td>{d.status?.battery ? `Bat ${d.status.battery}%` : ''}</td>
+              <td>
+                {d.status?.battery ? `Bat ${d.status.battery}%` : ''}
+                {d.status?.rootAttempt ? ' Root' : ''}
+              </td>
             </tr>
           ))}
         </tbody>
@@ -220,6 +223,7 @@ function DeviceDetails({ id, onBack }) {
           <p>Serial: {info.serial}</p>
           <p>IMEI: {info.imei}</p>
           <p>Batería: {info.status?.battery ?? 'N/A'}%</p>
+          <p>Intento de root: {info.status?.rootAttempt ? 'Sí' : 'No'}</p>
         </div>
       )}
       <div className="actions">


### PR DESCRIPTION
## Summary
- extend device status model to include integrity flags
- send device integrity updates to server
- expose root attempt details in admin panel

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689809426de48320b1391998c77f0ceb