### PR TITLE
Add device security event reporting

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -38,6 +38,16 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".receivers.SecurityEventReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.FACTORY_RESET" />
+            </intent-filter>
+        </receiver>
+
         <!-- Servicio MDM -->
         <service
             android:name=".services.MDMService"

--- a/mobile/app/src/main/java/com/example/mdmjive/network/models/DeviceStatus.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/network/models/DeviceStatus.kt
@@ -3,5 +3,7 @@ package com.example.mdmjive.network.models
 data class DeviceStatus(
     val deviceId: String,
     val status: String,
-    val lastUpdate: Long = System.currentTimeMillis()
+    val wipeDetected: Boolean = false,
+    val bootloaderTampered: Boolean = false,
+    val lastSync: Long = System.currentTimeMillis()
 )

--- a/mobile/app/src/main/java/com/example/mdmjive/receivers/SecurityEventReceiver.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/receivers/SecurityEventReceiver.kt
@@ -1,0 +1,49 @@
+package com.example.mdmjive.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.example.mdmjive.BuildConfig
+import com.example.mdmjive.database.LogDatabase
+import com.example.mdmjive.network.ApiServiceFactory
+import com.example.mdmjive.repository.DeviceRepository
+import java.io.File
+
+class SecurityEventReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d("SecurityEventReceiver", "Received ${intent.action}")
+
+        val sentinel = File(context.filesDir, "boot_sentinel")
+        val wipeDetected = !sentinel.exists()
+        if (wipeDetected) {
+            try {
+                sentinel.createNewFile()
+            } catch (_: Exception) {
+            }
+        }
+
+        val bootState = getVerifiedBootState()
+        val bootloaderTampered = bootState.isNotEmpty() && bootState != "green"
+
+        val repository = DeviceRepository(
+            ApiServiceFactory.create(BuildConfig.BASE_URL),
+            LogDatabase.getDatabase(context).deviceDao()
+        )
+        try {
+            repository.reportSecurityEvent(context, wipeDetected, bootloaderTampered)
+        } catch (e: Exception) {
+            Log.e("SecurityEventReceiver", "Error sending security event: ${e.localizedMessage}")
+        }
+    }
+
+    private fun getVerifiedBootState(): String {
+        return try {
+            val clazz = Class.forName("android.os.SystemProperties")
+            val method = clazz.getMethod("get", String::class.java, String::class.java)
+            method.invoke(null, "ro.boot.verifiedbootstate", "") as String
+        } catch (e: Exception) {
+            ""
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/example/mdmjive/repository/DeviceRepository.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/repository/DeviceRepository.kt
@@ -110,6 +110,27 @@ class DeviceRepository(
         }
     }
 
+    // Reporta eventos de seguridad al servidor
+    suspend fun reportSecurityEvent(
+        context: android.content.Context,
+        wipeDetected: Boolean,
+        bootloaderTampered: Boolean
+    ) {
+        val deviceId = getDeviceId(context)
+        val status = DeviceStatus(
+            deviceId = deviceId,
+            status = "ACTIVE",
+            wipeDetected = wipeDetected,
+            bootloaderTampered = bootloaderTampered,
+            lastSync = currentSyncTime()
+        )
+        try {
+            apiService.updateStatus(status)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error reportando evento de seguridad: ${e.localizedMessage}")
+        }
+    }
+
     // Sincronizar con servidor
     suspend fun syncWithServer() = withContext(Dispatchers.IO) {
         try {

--- a/server/admin-frontend/app.jsx
+++ b/server/admin-frontend/app.jsx
@@ -50,6 +50,8 @@ function Dashboard() {
     const s = d.status || {};
     if (s.battery && s.battery < 20) alerts.push(`Batería baja en ${d.deviceId} (${s.battery}%)`);
     if (s.rootAttempt) alerts.push(`Intento de root en ${d.deviceId}`);
+    if (s.wipeDetected) alerts.push(`Wipe detectado en ${d.deviceId}`);
+    if (s.bootloaderTampered) alerts.push(`Bootloader modificado en ${d.deviceId}`);
   });
   return (
     <div>


### PR DESCRIPTION
## Summary
- add SecurityEventReceiver for boot and wipe detection
- flag wipe and bootloader tamper in DeviceStatus and repository
- surface wipe and bootloader alerts in admin dashboard

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68980945cdcc83209bc225738e6845c7