### PR TITLE
Add security event receiver and admin alerts

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -38,6 +38,16 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".receivers.SecurityEventReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.FACTORY_RESET" />
+            </intent-filter>
+        </receiver>
+
         <!-- Servicio MDM -->
         <service
             android:name=".services.MDMService"

--- a/mobile/app/src/main/java/com/example/mdmjive/network/models/DeviceStatus.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/network/models/DeviceStatus.kt
@@ -6,5 +6,7 @@ data class DeviceStatus(
     val lastSync: Long = System.currentTimeMillis(),
     val rootAttempt: Boolean = false,
     val emulator: Boolean = false,
-    val unknownSources: Boolean = false
+    val unknownSources: Boolean = false,
+    val wipeDetected: Boolean = false,
+    val bootloaderTampered: Boolean = false
 )

--- a/mobile/app/src/main/java/com/example/mdmjive/receivers/SecurityEventReceiver.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/receivers/SecurityEventReceiver.kt
@@ -1,0 +1,53 @@
+package com.example.mdmjive.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import android.util.Log
+import com.example.mdmjive.BuildConfig
+import com.example.mdmjive.network.ApiServiceFactory
+import com.example.mdmjive.network.models.DeviceStatus
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+class SecurityEventReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val sentinel = File(context.filesDir, "sentinel")
+        val wipeDetected = !sentinel.exists()
+        if (wipeDetected) {
+            try {
+                sentinel.createNewFile()
+            } catch (e: Exception) {
+                Log.e("SecurityEventReceiver", "Failed to create sentinel", e)
+            }
+        }
+
+        val bootState = getSystemProperty("ro.boot.verifiedbootstate")
+        val bootloaderTampered = bootState.isNotEmpty() && bootState != "green"
+
+        val deviceId = Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+        val api = ApiServiceFactory.create(BuildConfig.BASE_URL)
+        val status = DeviceStatus(
+            deviceId = deviceId,
+            status = "OK",
+            wipeDetected = wipeDetected,
+            bootloaderTampered = bootloaderTampered
+        )
+        try {
+            runBlocking { api.updateStatus(status) }
+        } catch (e: Exception) {
+            Log.e("SecurityEventReceiver", "Failed to send status", e)
+        }
+    }
+
+    private fun getSystemProperty(name: String): String {
+        return try {
+            val cls = Class.forName("android.os.SystemProperties")
+            val method = cls.getMethod("get", String::class.java)
+            method.invoke(null, name) as String
+        } catch (e: Exception) {
+            ""
+        }
+    }
+}

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -371,6 +371,8 @@ def update_status(auth):
             'unknownSources',
             'lastSync',
             'battery',
+            'wipeDetected',
+            'bootloaderTampered',
         ):
             if field in data:
                 status[field] = data[field]

--- a/server/admin-frontend/app.jsx
+++ b/server/admin-frontend/app.jsx
@@ -50,6 +50,8 @@ function Dashboard() {
     const s = d.status || {};
     if (s.battery && s.battery < 20) alerts.push(`Batería baja en ${d.deviceId} (${s.battery}%)`);
     if (s.rootAttempt) alerts.push(`Intento de root en ${d.deviceId}`);
+    if (s.wipeDetected) alerts.push(`Wipe detectado en ${d.deviceId}`);
+    if (s.bootloaderTampered) alerts.push(`Bootloader alterado en ${d.deviceId}`);
   });
   return (
     <div>
@@ -102,6 +104,8 @@ function DeviceTable({ onSelect }) {
               <td>
                 {d.status?.battery ? `Bat ${d.status.battery}%` : ''}
                 {d.status?.rootAttempt ? ' Root' : ''}
+                {d.status?.wipeDetected ? ' Wipe' : ''}
+                {d.status?.bootloaderTampered ? ' Boot' : ''}
               </td>
             </tr>
           ))}
@@ -224,6 +228,8 @@ function DeviceDetails({ id, onBack }) {
           <p>IMEI: {info.imei}</p>
           <p>Batería: {info.status?.battery ?? 'N/A'}%</p>
           <p>Intento de root: {info.status?.rootAttempt ? 'Sí' : 'No'}</p>
+          <p>Wipe detectado: {info.status?.wipeDetected ? 'Sí' : 'No'}</p>
+          <p>Bootloader alterado: {info.status?.bootloaderTampered ? 'Sí' : 'No'}</p>
         </div>
       )}
       <div className="actions">


### PR DESCRIPTION
## Summary
- track wipe and bootloader tampering via new SecurityEventReceiver
- extend DeviceStatus and server/admin logic for new security flags

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68980bae4e8083208ed39f2c7cced772