### PR TITLE
Update client API endpoints and repository calls

### DIFF
--- a/mobile/app/src/androidTest/java/com/example/mdmjive/CommandReceptionInstrumentedTest.kt
+++ b/mobile/app/src/androidTest/java/com/example/mdmjive/CommandReceptionInstrumentedTest.kt
@@ -33,7 +33,7 @@ class CommandReceptionInstrumentedTest {
 
     @Test
     fun fetchCommands_returnsListFromApi() = runBlocking {
-        whenever(api.getCommands("android-device")).thenReturn(Response.success(listOf(Command("LOCK"))))
+        whenever(api.getCommands()).thenReturn(Response.success(listOf(Command("LOCK"))))
         val commands = repository.fetchCommands(context)
         assertEquals(1, commands.size)
         assertEquals("LOCK", commands[0].action)

--- a/mobile/app/src/main/java/com/example/mdmjive/network/ApiService.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/network/ApiService.kt
@@ -4,7 +4,6 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 import retrofit2.http.GET
-import retrofit2.http.Path
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import android.util.Log
@@ -20,14 +19,14 @@ interface ApiService {
     @POST("devices/register")
     suspend fun registerDevice(@Body deviceInfo: DeviceInfo): Response<ApiResponse>
 
-    @POST("devices/status")
+    @POST("client/devices/status")
     suspend fun updateStatus(@Body status: DeviceStatus): Response<ApiResponse>
 
-    @POST("logs")
+    @POST("client/logs")
     suspend fun uploadLogs(@Body payload: LogPayload): Response<ApiResponse>
 
-    @GET("commands/{deviceId}")
-    suspend fun getCommands(@Path("deviceId") deviceId: String): Response<List<Command>>
+    @GET("client/commands")
+    suspend fun getCommands(): Response<List<Command>>
 
     @POST("commands")
     suspend fun sendCommand(@Body command: Command): Response<ApiResponse>

--- a/mobile/app/src/main/java/com/example/mdmjive/repository/DeviceRepository.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/repository/DeviceRepository.kt
@@ -134,8 +134,7 @@ class DeviceRepository(
 
     suspend fun fetchCommands(context: android.content.Context): List<Command> = withContext(Dispatchers.IO) {
         return@withContext try {
-            val deviceId = getDeviceId(context)
-            val response = apiService.getCommands(deviceId)
+            val response = apiService.getCommands()
             if (response.isSuccessful) {
                 response.body() ?: emptyList()
             } else {

--- a/mobile/app/src/test/java/com/example/mdmjive/DeviceRepositoryTest.kt
+++ b/mobile/app/src/test/java/com/example/mdmjive/DeviceRepositoryTest.kt
@@ -42,7 +42,7 @@ class DeviceRepositoryTest {
 
     @Test
     fun fetchCommands_returnsCommandsFromApi() = runBlocking {
-        whenever(apiService.getCommands("test-device")).thenReturn(Response.success(listOf(Command("LOCK"))))
+        whenever(apiService.getCommands()).thenReturn(Response.success(listOf(Command("LOCK"))))
         val result = repository.fetchCommands(context)
         assertEquals(1, result.size)
         assertEquals("LOCK", result.first().action)


### PR DESCRIPTION
## Summary
- route device status, logs, and command retrieval through new `/client` endpoints
- drop device ID from command retrieval and adjust repository calls
- update tests to mock new command endpoint

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_b_68981daceea88320beb80f3b9f36f46f