### PR TITLE
feat: add auth token support

### DIFF
--- a/mobile/app/src/main/java/com/example/mdmjive/core/MDMCore.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/core/MDMCore.kt
@@ -18,7 +18,7 @@ class MDMCore private constructor(private val context: Context) {
         policyManager = PolicyManager(context)
         securityChecker = SecurityChecker
         deviceMonitor = DeviceMonitor(context)
-        logManager = LogManager(LogDatabase.getDatabase(context))
+        logManager = LogManager(LogDatabase.getDatabase(context), context)
     }
 
     companion object {

--- a/mobile/app/src/main/java/com/example/mdmjive/monitoring/LogManager.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/monitoring/LogManager.kt
@@ -1,6 +1,8 @@
 package com.example.mdmjive.monitoring
 
 import android.util.Log
+import android.content.Context
+import com.example.mdmjive.utils.TokenManager
 import com.example.mdmjive.BuildConfig
 import com.example.mdmjive.database.LogDatabase
 import com.example.mdmjive.database.entities.LogEntry
@@ -11,7 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class LogManager(private val logDatabase: LogDatabase) {
+class LogManager(private val logDatabase: LogDatabase, private val context: Context) {
 
     private val apiService = ApiServiceFactory.create(BuildConfig.BASE_URL)
 
@@ -71,7 +73,13 @@ class LogManager(private val logDatabase: LogDatabase) {
                     }
                 )
 
-                apiService.uploadLogs(payload)
+                val token = TokenManager.getToken(context)
+                if (token == null) {
+                    Log.e("LogManager", "Token no disponible")
+                    return@launch
+                }
+                val bearer = "Bearer $token"
+                apiService.uploadLogs(bearer, payload)
                 logDatabase.logDao().clearLogs()
             } catch (e: Exception) {
                 Log.e("LogManager", "Error subiendo logs: ${e.message}")

--- a/mobile/app/src/main/java/com/example/mdmjive/network/ApiService.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/network/ApiService.kt
@@ -4,6 +4,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import android.util.Log
@@ -20,16 +21,27 @@ interface ApiService {
     suspend fun registerDevice(@Body deviceInfo: DeviceInfo): Response<ApiResponse>
 
     @POST("client/devices/status")
-    suspend fun updateStatus(@Body status: DeviceStatus): Response<ApiResponse>
+    suspend fun updateStatus(
+        @Header("Authorization") token: String,
+        @Body status: DeviceStatus
+    ): Response<ApiResponse>
 
     @POST("client/logs")
-    suspend fun uploadLogs(@Body payload: LogPayload): Response<ApiResponse>
+    suspend fun uploadLogs(
+        @Header("Authorization") token: String,
+        @Body payload: LogPayload
+    ): Response<ApiResponse>
 
     @GET("client/commands")
-    suspend fun getCommands(): Response<List<Command>>
+    suspend fun getCommands(
+        @Header("Authorization") token: String
+    ): Response<List<Command>>
 
     @POST("commands")
-    suspend fun sendCommand(@Body command: Command): Response<ApiResponse>
+    suspend fun sendCommand(
+        @Header("Authorization") token: String,
+        @Body command: Command
+    ): Response<ApiResponse>
 }
 
 
@@ -64,13 +76,15 @@ object ApiHandler {
 class DeviceOperations(private val apiService: ApiService) {
     suspend fun registerDeviceAndUpdateStatus(
         deviceInfo: DeviceInfo,
-        deviceStatus: DeviceStatus
+        deviceStatus: DeviceStatus,
+        token: String
     ): ApiResult<Boolean> {
         return try {
             when (val registerResult = ApiHandler.safeApiCall { apiService.registerDevice(deviceInfo) }) {
                 is ApiResult.Success -> {
                     if (registerResult.data.success) {
-                        when (val statusResult = ApiHandler.safeApiCall { apiService.updateStatus(deviceStatus) }) {
+                        val bearer = "Bearer $token"
+                        when (val statusResult = ApiHandler.safeApiCall { apiService.updateStatus(bearer, deviceStatus) }) {
                             is ApiResult.Success -> {
                                 ApiResult.Success(true)
                             }

--- a/mobile/app/src/main/java/com/example/mdmjive/receivers/SecurityEventReceiver.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/receivers/SecurityEventReceiver.kt
@@ -10,6 +10,7 @@ import com.example.mdmjive.network.ApiServiceFactory
 import com.example.mdmjive.network.models.DeviceStatus
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import com.example.mdmjive.utils.TokenManager
 
 class SecurityEventReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -34,10 +35,16 @@ class SecurityEventReceiver : BroadcastReceiver() {
             wipeDetected = wipeDetected,
             bootloaderTampered = bootloaderTampered
         )
-        try {
-            runBlocking { api.updateStatus(status) }
-        } catch (e: Exception) {
-            Log.e("SecurityEventReceiver", "Failed to send status", e)
+        val token = TokenManager.getToken(context)
+        if (token != null) {
+            try {
+                val bearer = "Bearer $token"
+                runBlocking { api.updateStatus(bearer, status) }
+            } catch (e: Exception) {
+                Log.e("SecurityEventReceiver", "Failed to send status", e)
+            }
+        } else {
+            Log.e("SecurityEventReceiver", "Token no disponible")
         }
     }
 

--- a/mobile/app/src/main/java/com/example/mdmjive/repository/DeviceRepository.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/repository/DeviceRepository.kt
@@ -12,6 +12,7 @@ import android.telephony.TelephonyManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import android.util.Log
+import com.example.mdmjive.utils.TokenManager
 
 class DeviceRepository(
     private val apiService: ApiService,
@@ -90,6 +91,11 @@ class DeviceRepository(
 
     // Actualizar estado
     suspend fun updateDeviceStatus(context: android.content.Context, newStatus: String) {
+        val token = TokenManager.getToken(context)
+        if (token == null) {
+            Log.e(TAG, "Token no disponible")
+            return
+        }
         val deviceId = getDeviceId(context)
         val status = DeviceStatus(
             deviceId = deviceId,
@@ -98,7 +104,8 @@ class DeviceRepository(
         )
 
         try {
-            val response = apiService.updateStatus(status)
+            val bearer = "Bearer $token"
+            val response = apiService.updateStatus(bearer, status)
             if (response.isSuccessful) {
                 deviceDao.updateDeviceStatus(deviceId, newStatus, currentSyncTime())
                 Log.d(TAG, "Estado del dispositivo actualizado")
@@ -111,7 +118,13 @@ class DeviceRepository(
     }
 
     // Sincronizar con servidor
-    suspend fun syncWithServer() = withContext(Dispatchers.IO) {
+    suspend fun syncWithServer(context: android.content.Context) = withContext(Dispatchers.IO) {
+        val token = TokenManager.getToken(context)
+        if (token == null) {
+            Log.e(TAG, "Token no disponible")
+            return@withContext
+        }
+        val bearer = "Bearer $token"
         try {
             val localDevices = deviceDao.getAllDevices()
             localDevices.forEach { device ->
@@ -120,7 +133,7 @@ class DeviceRepository(
                     status = device.status,
                     lastSync = device.lastSync
                 )
-                val response = apiService.updateStatus(status)
+                val response = apiService.updateStatus(bearer, status)
                 if (response.isSuccessful) {
                     Log.d(TAG, "Dispositivo ${device.deviceId} sincronizado exitosamente")
                 } else {
@@ -134,7 +147,13 @@ class DeviceRepository(
 
     suspend fun fetchCommands(context: android.content.Context): List<Command> = withContext(Dispatchers.IO) {
         return@withContext try {
-            val response = apiService.getCommands()
+            val token = TokenManager.getToken(context)
+            if (token == null) {
+                Log.e(TAG, "Token no disponible")
+                return@withContext emptyList()
+            }
+            val bearer = "Bearer $token"
+            val response = apiService.getCommands(bearer)
             if (response.isSuccessful) {
                 response.body() ?: emptyList()
             } else {

--- a/mobile/app/src/main/java/com/example/mdmjive/security/DeviceCertificationManager.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/security/DeviceCertificationManager.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import com.example.mdmjive.network.ApiService
 import com.example.mdmjive.network.models.DeviceStatus
 import kotlinx.coroutines.runBlocking
+import com.example.mdmjive.utils.TokenManager
 
 class DeviceCertificationManager(
     private val context: Context,
@@ -32,10 +33,16 @@ class DeviceCertificationManager(
             emulator = isEmulator,
             unknownSources = hasUnknownSources
         )
-        try {
-            runBlocking { apiService.updateStatus(deviceStatus) }
-        } catch (e: Exception) {
-            Log.e("DeviceCertificationManager", "Failed to update status", e)
+        val token = TokenManager.getToken(context)
+        if (token != null) {
+            try {
+                val bearer = "Bearer $token"
+                runBlocking { apiService.updateStatus(bearer, deviceStatus) }
+            } catch (e: Exception) {
+                Log.e("DeviceCertificationManager", "Failed to update status", e)
+            }
+        } else {
+            Log.e("DeviceCertificationManager", "Token no disponible")
         }
 
         return DeviceIntegrityResult(

--- a/mobile/app/src/main/java/com/example/mdmjive/services/FCMService.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/services/FCMService.kt
@@ -11,11 +11,13 @@ import com.example.mdmjive.controls.CommandExecutor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import com.example.mdmjive.utils.TokenManager
 
 class FCMService : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         Log.d("FCMService", "Nuevo token: $token")
+        TokenManager.saveToken(applicationContext, token)
     }
 
     override fun onMessageReceived(message: RemoteMessage) {

--- a/mobile/app/src/main/java/com/example/mdmjive/utils/TokenManager.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/utils/TokenManager.kt
@@ -1,0 +1,18 @@
+package com.example.mdmjive.utils
+
+import android.content.Context
+
+object TokenManager {
+    private const val PREFS_NAME = "mdm_prefs"
+    private const val KEY_TOKEN = "jwt_token"
+
+    fun saveToken(context: Context, token: String) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putString(KEY_TOKEN, token).apply()
+    }
+
+    fun getToken(context: Context): String? {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return prefs.getString(KEY_TOKEN, null)
+    }
+}

--- a/mobile/app/src/main/java/com/example/mdmjive/workers/SyncWorker.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/workers/SyncWorker.kt
@@ -28,7 +28,7 @@ class SyncWorker(
             Log.d(TAG, "Iniciando la sincronización del dispositivo...")
 
             // Llamada al repositorio para sincronizar
-            deviceRepository.syncWithServer()
+            deviceRepository.syncWithServer(applicationContext)
 
             val commands = deviceRepository.fetchCommands(applicationContext)
             if (commands.isNotEmpty()) {


### PR DESCRIPTION
## Summary
- add Authorization header support to API calls
- persist FCM token and reuse it for authenticated requests
- secure log uploads and device sync using saved token

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68981efc9db88320b9cfeade7a6f7d24