### PR TITLE
Load BASE_URL from Gradle properties or flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ BizonMDM es una plataforma de Mobile Device Management (MDM) de código abierto.
 
 - `mobile/`: aplicación móvil Android.
   - El servicio MDM se ejecuta como foreground y muestra una notificación persistente.
-  - La URL del servidor se configura mediante `BuildConfig.BASE_URL` en `mobile/app/build.gradle.kts`.
+  - La URL del servidor se obtiene de `BuildConfig.BASE_URL`, definida a través de `gradle.properties`, variables de entorno o las `productFlavors` `dev` y `prod` en `mobile/app/build.gradle.kts`.
 - `server/`: componentes del servidor y del panel web.
   - `Servidor/`: API en Flask, modelos de base de datos y scripts de instalación.
   - `admin/`, `alerts/`, `client/`, `device/`, `documents/`, `financing/`, `tasks/`: módulos Python que implementan la lógica del backend.
@@ -22,6 +22,31 @@ BizonMDM es una plataforma de Mobile Device Management (MDM) de código abierto.
   - `install.py` e `instalacion_bizonmdm.html`: utilidades para la instalación.
   - `SUBDOMAIN_SETUP.md`: ejemplo de configuración de NGINX/Apache para servir varios subdominios.
 - `docs/`: documentación adicional incluyendo `documentation.html`.
+
+### Configurar la URL del servidor en la app móvil
+
+La aplicación obtiene la dirección del backend desde `BuildConfig.BASE_URL`. El valor puede definirse de las siguientes maneras:
+
+- **`gradle.properties`** (`mobile/gradle.properties`):
+
+  ```
+  DEV_BASE_URL=https://dev.tuservidor.com/
+  PROD_BASE_URL=https://tuservidor.com/
+  ```
+
+- **Variables de entorno**:
+
+  ```
+  export DEV_BASE_URL=https://dev.tuservidor.com/
+  export PROD_BASE_URL=https://tuservidor.com/
+  ```
+
+Compila usando el flavor deseado:
+
+```
+./gradlew assembleDevDebug    # usa DEV_BASE_URL
+./gradlew assembleProdRelease # usa PROD_BASE_URL
+```
 
 ## Instalación rápida
 

--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
     id("kotlin-kapt")  // Este es necesario para Room
 }
 
+val devBaseUrl: String = project.findProperty("DEV_BASE_URL") as String? ?: System.getenv("DEV_BASE_URL") ?: ""
+val prodBaseUrl: String = project.findProperty("PROD_BASE_URL") as String? ?: System.getenv("PROD_BASE_URL") ?: ""
+
 android {
     namespace = "com.example.mdmjive"
     compileSdk = 34
@@ -15,8 +18,6 @@ android {
         versionCode = 1
         versionName = "1.0"
 
-        buildConfigField("String", "BASE_URL", "\"https://example.com/\"")
-
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments += mapOf(
@@ -24,6 +25,19 @@ android {
                     "room.incremental" to "true"  // Habilitar la compilación incremental
                 )
             }
+        }
+    }
+
+    flavorDimensions += listOf("environment")
+
+    productFlavors {
+        create("dev") {
+            dimension = "environment"
+            buildConfigField("String", "BASE_URL", "\"$devBaseUrl\"")
+        }
+        create("prod") {
+            dimension = "environment"
+            buildConfigField("String", "BASE_URL", "\"$prodBaseUrl\"")
         }
     }
 


### PR DESCRIPTION
## Summary
- Read dev and prod base URLs from Gradle properties or environment variables in the Android app
- Document how to configure DEV_BASE_URL and PROD_BASE_URL for each environment

## Testing
- `./gradlew help` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6898208c3bc883208409d6a38b481c9e