### PR TITLE
Parse FCM data and execute commands

### DIFF
--- a/mobile/app/src/main/java/com/example/mdmjive/services/FCMService.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/services/FCMService.kt
@@ -3,15 +3,12 @@ package com.example.mdmjive.services
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import android.util.Log
-import com.example.mdmjive.BuildConfig
-import com.example.mdmjive.repository.DeviceRepository
-import com.example.mdmjive.network.ApiServiceFactory
-import com.example.mdmjive.database.LogDatabase
 import com.example.mdmjive.controls.CommandExecutor
+import com.example.mdmjive.network.models.Command
+import com.example.mdmjive.utils.TokenManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import com.example.mdmjive.utils.TokenManager
 
 class FCMService : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
@@ -23,13 +20,16 @@ class FCMService : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
         CoroutineScope(Dispatchers.IO).launch {
-            val repository = DeviceRepository(
-                ApiServiceFactory.create(BuildConfig.BASE_URL),
-                LogDatabase.getDatabase(applicationContext).deviceDao()
-            )
-            val commands = repository.fetchCommands(applicationContext)
-            if (commands.isNotEmpty()) {
-                CommandExecutor(applicationContext).execute(commands)
+            val action = message.data["action"]
+            if (action != null) {
+                val command = Command(
+                    action = action,
+                    packageName = message.data["packageName"],
+                    message = message.data["message"]
+                )
+                CommandExecutor(applicationContext).execute(listOf(command))
+            } else {
+                Log.e("FCMService", "Acción no proporcionada en el mensaje FCM")
             }
         }
     }


### PR DESCRIPTION
## Summary
- parse FCM data payload for command information and execute it directly

## Testing
- `gradle test` *(fails: SDK location not found)*
- `sudo apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689822432724832097adb127b559949c