### PR TITLE
refactor: reference device admin receiver class

### DIFF
--- a/mobile/app/src/main/java/com/example/mdmjive/security/PolicyManager.kt
+++ b/mobile/app/src/main/java/com/example/mdmjive/security/PolicyManager.kt
@@ -5,10 +5,11 @@ import android.content.Context
 import android.content.ComponentName
 import android.util.Log
 import android.os.UserManager
+import com.example.mdmjive.receivers.MDMDeviceAdminReceiver
 
 class PolicyManager(private val context: Context) {
     private val dpm = context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
-    private val componentName = ComponentName(context, "com.example.mdmjive.receivers.MDMDeviceAdminReceiver")
+    private val componentName = ComponentName(context, MDMDeviceAdminReceiver::class.java)
 
     fun enforcePasswordPolicy() {
         try {


### PR DESCRIPTION
## Summary
- import `MDMDeviceAdminReceiver` in `PolicyManager`
- reference `MDMDeviceAdminReceiver` class when creating `ComponentName`

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68982368f388832085130de40aa7412c