### PR TITLE
Require DATABASE_URL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ docker-compose up -d
 
 Accede al panel en `http://localhost:5000`.
 
-### Variables de entorno opcionales
+### Variables de entorno
 
-Puedes definir variables antes de levantar los contenedores:
+Define variables antes de levantar los contenedores:
 
-- `DATABASE_URL`: cadena de conexión a la base de datos (por defecto `postgresql+psycopg2://postgres:postgres@db:5432/bizon`).
-- `BIZON_HOST`: dirección en la que el servidor escucha (por defecto `0.0.0.0`).
-- `BIZON_PORT`: puerto interno del servidor (por defecto `5000`).
+- `DATABASE_URL`: cadena de conexión a la base de datos. **Obligatoria**.
+- `BIZON_HOST`: dirección en la que el servidor escucha (opcional, por defecto `0.0.0.0`).
+- `BIZON_PORT`: puerto interno del servidor (opcional, por defecto `5000`).
 - `JWT_SECRET`: clave para firmar tokens JWT.
 - `FCM_SERVER_KEY`: clave de Firebase Cloud Messaging para notificaciones.
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -252,7 +252,7 @@ python server/install.py</code></pre>
       <li>Instalador web: <code>/install</code> crea <code>.env</code>, guarda la clave FCM y ejecuta migraciones (Alembic).</li>
       <li>Variables principales:
         <ul>
-          <li><code>DATABASE_URL</code> — cadena de conexión (PostgreSQL, MySQL/MariaDB o SQLite).</li>
+            <li><code>DATABASE_URL</code> — cadena de conexión (PostgreSQL, MySQL/MariaDB o SQLite). <strong>Obligatoria</strong>.</li>
           <li><code>JWT_SECRET</code> — clave secreta para firmar tokens.</li>
           <li><code>FCM_SERVER_KEY</code> — clave de servidor de Firebase Cloud Messaging.</li>
           <li><code>ADMIN_EMAIL</code>, <code>ADMIN_PASSWORD</code> — usuario inicial.</li>

--- a/server/Servidor/models.py
+++ b/server/Servidor/models.py
@@ -15,8 +15,11 @@ from sqlalchemy import (
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker
 from sqlalchemy.sql import func
 
-DEFAULT_DB_URL = "postgresql+psycopg2://postgres:postgres@localhost/bizon"
-DB_URL = os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+try:
+    DB_URL = os.environ["DATABASE_URL"]
+except KeyError as exc:
+    raise RuntimeError("DATABASE_URL environment variable is required") from exc
+
 engine = create_engine(DB_URL, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 


### PR DESCRIPTION
## Summary
- enforce DATABASE_URL presence and raise error if missing
- document DATABASE_URL as mandatory for deployment

## Testing
- `pytest server/Servidor/tests/test_server.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689827d685f88320b4afec6f6c4df346