### PR TITLE
feat: secure device registration

### DIFF
--- a/server/Servidor/README.md
+++ b/server/Servidor/README.md
@@ -127,6 +127,24 @@ Todos los endpoints responden con un JSON similar a:
 - `GET /commands/<deviceId>` – obtiene y limpia los comandos para el dispositivo.
 - `GET /provisioning/qr/<deviceId>` – genera el código QR de aprovisionamiento.
 
+## Registro seguro de dispositivos
+
+Para evitar altas no autorizadas define la variable de entorno `REGISTRATION_TOKEN`.
+Mientras esté configurada, el endpoint público `/devices/register` exigirá el
+encabezado `X-Registration-Token` con dicho valor. Genera un token temporal y
+compártelo por un canal seguro. Como alternativa, utiliza el endpoint
+`/admin/devices/register` junto con un token JWT de administrador.
+
+Ejemplo:
+
+```bash
+export REGISTRATION_TOKEN=secreto-temporal
+curl -X POST http://localhost:5000/devices/register \
+  -H 'Content-Type: application/json' \
+  -H 'X-Registration-Token: secreto-temporal' \
+  -d '{"deviceId": "123"}'
+```
+
 Este servidor es un ejemplo para desarrollo y pruebas.
 
 Para una guía más detallada consulta [MANUAL.md](MANUAL.md).

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -49,6 +49,7 @@ if os.path.exists(ENV_PATH):
                 os.environ.setdefault(k, v)
 
 JWT_SECRET = os.getenv("JWT_SECRET")
+REGISTRATION_TOKEN = os.getenv("REGISTRATION_TOKEN")
 FCM_SERVER_KEY = os.getenv("FCM_SERVER_KEY")
 FCM_URL = "https://fcm.googleapis.com/fcm/send"
 logging.basicConfig(filename="server.log", level=logging.INFO,
@@ -347,6 +348,10 @@ def register_device_admin():
 @app.route('/devices/register', methods=['POST'])
 def register_device_public():
     """Endpoint público para registrar dispositivos."""
+    if REGISTRATION_TOKEN:
+        token = request.headers.get('X-Registration-Token')
+        if token != REGISTRATION_TOKEN:
+            return jsonify({'success': False, 'message': 'Unauthorized'}), 401
     return _register_device()
 
 @app.route('/client/devices/status', methods=['POST'])

--- a/server/Servidor/tests/test_server.py
+++ b/server/Servidor/tests/test_server.py
@@ -10,6 +10,7 @@ DB_FD, DB_PATH = tempfile.mkstemp()
 os.environ['DATABASE_URL'] = f'sqlite:///{DB_PATH}'
 os.environ['JWT_SECRET'] = 'testsecret'
 os.environ['SKIP_ALEMBIC'] = '1'
+os.environ['REGISTRATION_TOKEN'] = 'testreg'
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from server import app, init_db, encode_jwt, decode_jwt, get_session
@@ -223,9 +224,23 @@ class ServerTestCase(unittest.TestCase):
         self.assertFalse(ok)
         server.FCM_SERVER_KEY = None
 
+    def test_register_requires_token(self):
+        resp = self.client.post('/devices/register', json={'deviceId': 'dX'})
+        self.assertEqual(resp.status_code, 401)
+        resp = self.client.post(
+            '/devices/register',
+            json={'deviceId': 'dX'},
+            headers={'X-Registration-Token': os.environ['REGISTRATION_TOKEN']},
+        )
+        self.assertEqual(resp.status_code, 200)
+
     def test_admin_clients_crud(self):
         # Register a device to assign later
-        self.client.post('/devices/register', json={'deviceId': 'd1'})
+        self.client.post(
+            '/devices/register',
+            json={'deviceId': 'd1'},
+            headers={'X-Registration-Token': os.environ['REGISTRATION_TOKEN']},
+        )
         resp = self.client.post(
             '/admin/clients',
             json={'username': 'cli', 'password': 'pwd', 'permissions': ['wipe']},


### PR DESCRIPTION
## Summary
- require X-Registration-Token header for public device registration when REGISTRATION_TOKEN is set
- document secure registration flow
- test registration token requirement

## Testing
- `pip install -r server/Servidor/requirements.txt`
- `pytest tests/test_server.py`


------
https://chatgpt.com/codex/tasks/task_b_689827f090408320805b719cc0245df8