### PR TITLE
Add CI workflow and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r server/Servidor/requirements.txt
+          pip install pytest
+      - name: Run pytest
+        run: pytest
+
+  android-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Grant execute permission
+        run: chmod +x mobile/gradlew
+      - name: Build with Gradle
+        working-directory: mobile
+        run: ./gradlew build --stacktrace

--- a/mobile/app/src/test/java/com/example/mdmjive/ApiServiceTest.kt
+++ b/mobile/app/src/test/java/com/example/mdmjive/ApiServiceTest.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import kotlin.test.assertTrue
 import retrofit2.Response
+import okhttp3.ResponseBody
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 
 class ApiServiceTest {
     @Test
@@ -17,6 +19,13 @@ class ApiServiceTest {
     @Test
     fun safeApiCall_handlesException() = runBlocking {
         val result = ApiHandler.safeApiCall<String> { throw RuntimeException("boom") }
+        assertTrue(result is ApiResult.Error)
+    }
+
+    @Test
+    fun safeApiCall_handlesHttpError() = runBlocking {
+        val body = ResponseBody.create("text/plain".toMediaTypeOrNull(), "not found")
+        val result = ApiHandler.safeApiCall<String> { Response.error(404, body) }
         assertTrue(result is ApiResult.Error)
     }
 }

--- a/tests/test_server_endpoints.py
+++ b/tests/test_server_endpoints.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import tempfile
+import pathlib
+import pytest
+
+# Ensure server modules are importable
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT / "server" / "Servidor"))
+
+# Configure environment for testing
+os.environ["JWT_SECRET"] = "testsecret"
+os.environ["SKIP_ALEMBIC"] = "1"
+os.environ["REGISTRATION_TOKEN"] = "testreg"
+
+@pytest.fixture()
+def test_app():
+    """Yield a Flask test client and related helpers using a temp database."""
+    fd, path = tempfile.mkstemp()
+    os.environ["DATABASE_URL"] = f"sqlite:///{path}"
+    import importlib
+    import server as server_module
+    import models as models_module
+    server_module = importlib.reload(server_module)
+    models_module = importlib.reload(models_module)
+    server_module.init_db(drop=True)
+    import werkzeug
+    if not hasattr(werkzeug, "__version__"):
+        werkzeug.__version__ = "3"
+    with server_module.app.test_client() as client:
+        yield client, server_module, models_module
+    os.close(fd)
+    os.unlink(path)
+
+
+def test_login_endpoint(test_app):
+    """Admin can obtain a valid token via /login."""
+    client, server_module, models_module = test_app
+    with server_module.get_session() as db:
+        admin = models_module.Admin(username="adm")
+        admin.set_password("pwd")
+        db.add(admin)
+        db.commit()
+    resp = client.post("/login", json={"username": "adm", "password": "pwd"})
+    assert resp.status_code == 200
+    payload = server_module.decode_jwt(resp.get_json()["token"], os.environ["JWT_SECRET"])
+    assert payload["role"] == "admin"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running pytest and Gradle build
- cover Flask login endpoint with pytest
- extend Kotlin API service tests for HTTP error handling

## Testing
- `pytest tests/test_server_endpoints.py`
- `pytest` *(fails: sqlite3.OperationalError: attempt to write a readonly database)*
- `cd mobile && ./gradlew test` *(fails: java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68983399f1488320a37f216115838b1e