### PR TITLE
Add domain and API credentials to store model

### DIFF
--- a/server/Servidor/alembic/versions/0006_store_api_credentials.py
+++ b/server/Servidor/alembic/versions/0006_store_api_credentials.py
@@ -1,0 +1,21 @@
+"""add domain and api auth fields to stores"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0006_store_api_credentials'
+down_revision = '0005_admin_password_hash'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('stores', sa.Column('domain', sa.String(), nullable=True))
+    op.add_column('stores', sa.Column('api_user', sa.String(), nullable=True))
+    op.add_column('stores', sa.Column('api_password_hash', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('stores', 'api_password_hash')
+    op.drop_column('stores', 'api_user')
+    op.drop_column('stores', 'domain')

--- a/server/Servidor/models.py
+++ b/server/Servidor/models.py
@@ -30,9 +30,20 @@ class Store(Base):
     __tablename__ = "stores"
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True, nullable=False)
+    domain = Column(String)
+    api_user = Column(String)
+    api_password_hash = Column(String)
 
     users = relationship("User", back_populates="store", cascade="all, delete-orphan")
     clients = relationship("Client", back_populates="store", cascade="all, delete-orphan")
+
+    def set_api_password(self, password: str) -> None:
+        self.api_password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+    def check_api_password(self, password: str) -> bool:
+        if not self.api_password_hash:
+            return False
+        return bcrypt.checkpw(password.encode(), self.api_password_hash.encode())
 
 
 client_devices = Table(

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -204,6 +204,32 @@ def api_stores():
         return jsonify({'id': store.id, 'name': store.name}), 201
 
 
+@app.route('/api/stores/<int:store_id>/domain', methods=['GET', 'POST'])
+def store_domain(store_id: int):
+    auth = require_auth(request)
+    if not auth:
+        return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+    with get_session() as db:
+        store = db.query(Store).filter_by(id=store_id).first()
+        if not store:
+            return jsonify({'success': False, 'message': 'Store not found'}), 404
+        if auth.get('role') not in {'admin', 'user'}:
+            return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+        if auth.get('role') == 'user' and auth.get('store_id') != store_id:
+            return jsonify({'success': False, 'message': 'Unauthorized'}), 401
+        if request.method == 'GET':
+            return jsonify({'domain': store.domain, 'api_user': store.api_user}), 200
+        data = request.get_json() or {}
+        if 'domain' in data:
+            store.domain = data['domain']
+        if 'api_user' in data:
+            store.api_user = data['api_user']
+        if data.get('api_password'):
+            store.set_api_password(data['api_password'])
+        db.commit()
+        return jsonify({'success': True, 'domain': store.domain, 'api_user': store.api_user}), 200
+
+
 @app.route('/api/users', methods=['GET', 'POST'])
 def api_users():
     auth = require_auth(request)


### PR DESCRIPTION
## Summary
- extend `Store` model with `domain`, `api_user`, `api_password_hash` fields and hashing helpers
- expose REST endpoints to read/update store domain and API credentials
- add Alembic migration for new store fields

## Testing
- `pytest` *(fails: sqlite3.OperationalError attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_b_68983f25d9b48320be5f205cf4452084