### PR TITLE
Add financing views and contract summaries

### DIFF
--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -14,7 +14,9 @@ import qrcode
 import logging
 import urllib.request
 from functools import wraps
-from datetime import timedelta
+from datetime import timedelta, date
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from flask_jwt_extended import (
     JWTManager,
@@ -36,8 +38,6 @@ from models import (
     Store,
 )
 from sqlalchemy import text
-import sys
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from install import install_application
 
@@ -134,6 +134,13 @@ def require_auth(request) -> dict | None:
 def get_session():
     """Obtiene una nueva sesión de base de datos."""
     return SessionLocal()
+
+
+def get_financing_session():
+    """Obtiene una sesión de la base de datos de financiamiento."""
+    from financing.contracts.models import SessionLocal as FinancingSessionLocal
+
+    return FinancingSessionLocal()
 
 
 def require_admin(func):
@@ -738,6 +745,56 @@ def get_client_commands(auth):
     return jsonify(cmds), 200
 
 
+@app.route('/client/financing', methods=['GET'])
+@require_client
+def client_financing(auth):
+    """Devuelve contratos y próximos pagos para el cliente autenticado."""
+    client_id = int(auth.get('client_id'))
+    from financing.contracts.models import Contract as FinancingContract
+
+    with get_financing_session() as db:
+        contracts = (
+            db.query(FinancingContract)
+            .filter(FinancingContract.client_id == client_id)
+            .all()
+        )
+        result: list[dict[str, object]] = []
+        for contract in contracts:
+            schedules = contract.schedules
+            outstanding = sum(s.amount for s in schedules if not s.paid)
+            next_sched = None
+            for s in schedules:
+                if not s.paid and (next_sched is None or s.due_date < next_sched.due_date):
+                    next_sched = s
+            result.append(
+                {
+                    'id': contract.id,
+                    'amount': contract.amount,
+                    'outstanding': outstanding,
+                    'next_due_date': next_sched.due_date.isoformat() if next_sched else None,
+                    'next_due_amount': next_sched.amount if next_sched else None,
+                }
+            )
+    return jsonify(result), 200
+
+
+@app.route('/admin/contracts/summary', methods=['GET'])
+@require_admin
+def admin_contracts_summary():
+    """Devuelve estadísticas agregadas de contratos."""
+    today = date.today()
+    from financing.contracts.models import Contract as FinancingContract, PaymentSchedule
+
+    with get_financing_session() as db:
+        total = db.query(FinancingContract).count()
+        overdue = (
+            db.query(PaymentSchedule)
+            .filter(PaymentSchedule.due_date < today, PaymentSchedule.paid.is_(False))
+            .count()
+        )
+        paid = db.query(PaymentSchedule).filter(PaymentSchedule.paid.is_(True)).count()
+    return jsonify({'total': total, 'overdue': overdue, 'paid': paid}), 200
+
 # --- Endpoints de administración de clientes ---
 
 
@@ -833,8 +890,11 @@ if __name__ == '__main__':
     parser.add_argument('--init-db', action='store_true', help='Inicializar base de datos y salir')
     args = parser.parse_args()
 
+    from financing.contracts.models import init_db as init_financing_db
+
     if args.init_db:
         init_db(drop=True)
+        init_financing_db(drop=True)
         print('Base de datos inicializada')
     else:
         host = os.getenv('BIZON_HOST', '0.0.0.0')
@@ -843,4 +903,5 @@ if __name__ == '__main__':
         ssl_key = os.getenv('SSL_KEY')
         ssl_context = (ssl_cert, ssl_key) if ssl_cert and ssl_key else None
         init_db()
+        init_financing_db()
         app.run(host=host, port=port, ssl_context=ssl_context)

--- a/server/admin-frontend/admin/dashboard/index.jsx
+++ b/server/admin-frontend/admin/dashboard/index.jsx
@@ -1,24 +1,36 @@
 const { useState, useEffect } = React;
+const { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, CartesianGrid } = Recharts;
 
 function FinancialDashboard() {
-  const [data, setData] = useState({});
+  const [summary, setSummary] = useState(null);
 
   useEffect(() => {
     if (window.apiFetch) {
-      window.apiFetch('/api/finance')
-        .then(setData)
-        .catch(() => setData({}));
+      window.apiFetch('/api/contracts/summary')
+        .then(setSummary)
+        .catch(() => setSummary(null));
     }
   }, []);
 
+  if (!summary) return <div><h2>Contratos</h2><p>Sin datos</p></div>;
+
+  const data = [
+    { name: 'Total', value: summary.total },
+    { name: 'Vencidos', value: summary.overdue },
+    { name: 'Pagados', value: summary.paid },
+  ];
+
   return (
     <div>
-      <h2>Indicadores financieros</h2>
-      <ul>
-        <li>Ingresos: {data.revenue ?? 'N/D'}</li>
-        <li>Gastos: {data.expenses ?? 'N/D'}</li>
-        <li>Beneficio: {data.profit ?? 'N/D'}</li>
-      </ul>
+      <h2>Contratos</h2>
+      <BarChart width={400} height={250} data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis allowDecimals={false} />
+        <Tooltip />
+        <Legend />
+        <Bar dataKey="value" fill="#8884d8" />
+      </BarChart>
     </div>
   );
 }

--- a/server/admin-frontend/index.html
+++ b/server/admin-frontend/index.html
@@ -88,6 +88,7 @@
   <div id="root"></div>
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
     <script type="text/babel" src="admin/dashboard/index.jsx"></script>
     <script type="text/babel" src="admin/clients/index.jsx"></script>

--- a/server/client-frontend/app.jsx
+++ b/server/client-frontend/app.jsx
@@ -186,6 +186,44 @@ function DeviceDetails({ id, onBack }) {
   );
 }
 
+function Financing() {
+  const [contracts, setContracts] = useState([]);
+  useEffect(() => {
+    apiFetch('/financing').then(setContracts).catch(console.error);
+  }, []);
+  return (
+    <div>
+      <h2>Financiamiento</h2>
+      {contracts.length ? (
+        <table>
+          <thead>
+            <tr>
+              <th>Contrato</th>
+              <th>Saldo pendiente</th>
+              <th>Próximo vencimiento</th>
+            </tr>
+          </thead>
+          <tbody>
+            {contracts.map(c => (
+              <tr key={c.id}>
+                <td>Contrato {c.id}</td>
+                <td>{c.outstanding.toFixed(2)}</td>
+                <td>
+                  {c.next_due_date
+                    ? `${c.next_due_date} (${c.next_due_amount})`
+                    : 'Completado'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>Sin contratos</p>
+      )}
+    </div>
+  );
+}
+
 function DomainSetup() {
   const [domain, setDomain] = useState('');
   const [apiUser, setApiUser] = useState('');
@@ -247,6 +285,7 @@ function App() {
   if (route === '#/dashboard') page = <Dashboard />;
   else if (route === '#/domain') page = <DomainSetup />;
   else if (route === '#/devices') page = <DeviceTable onSelect={(id) => window.location.hash = `#/devices/${id}`} />;
+  else if (route === '#/financing') page = <Financing />;
   else if (route.startsWith('#/devices/')) {
     const id = route.split('/')[2];
     page = <DeviceDetails id={id} onBack={() => window.location.hash = '#/devices'} />;
@@ -261,6 +300,7 @@ function App() {
           <a href="#/dashboard">Dashboard</a>
           <a href="#/domain">Dominio</a>
           <a href="#/devices">Dispositivos</a>
+          <a href="#/financing">Financiamiento</a>
         </nav>
         <input value={token} onChange={handleTokenChange} placeholder="JWT token" style={{ marginLeft: '1rem' }} />
       </header>


### PR DESCRIPTION
## Summary
- expose client financing contracts and admin summaries via new endpoints
- display financed devices and upcoming payments on the client app
- show contract totals and payment status charts on admin dashboard

## Testing
- `pytest` *(fails: sqlite3.OperationalError: attempt to write a readonly database)*
- `cd server/client-frontend && npm test`
- `cd server/admin-frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_6898cdd297208320b89eff256c676c77