### PR TITLE
Add animated dashboards with KPI charts

### DIFF
--- a/server/admin-frontend/admin/dashboard/index.jsx
+++ b/server/admin-frontend/admin/dashboard/index.jsx
@@ -1,36 +1,77 @@
 const { useState, useEffect } = React;
 const { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, CartesianGrid } = Recharts;
+const { motion } = window.framerMotion || {};
 
 function FinancialDashboard() {
   const [summary, setSummary] = useState(null);
+  const [devices, setDevices] = useState([]);
 
   useEffect(() => {
     if (window.apiFetch) {
       window.apiFetch('/api/contracts/summary')
         .then(setSummary)
         .catch(() => setSummary(null));
+      window.apiFetch('/devices')
+        .then(setDevices)
+        .catch(() => setDevices([]));
     }
   }, []);
 
-  if (!summary) return <div><h2>Contratos</h2><p>Sin datos</p></div>;
+  const alerts = [];
+  devices.forEach(d => {
+    const s = d.status || {};
+    if (s.battery && s.battery < 20) alerts.push('b');
+    if (s.rootAttempt) alerts.push('r');
+    if (s.wipeDetected) alerts.push('w');
+    if (s.bootloaderTampered) alerts.push('t');
+  });
 
-  const data = [
+  const data = summary ? [
     { name: 'Total', value: summary.total },
     { name: 'Vencidos', value: summary.overdue },
     { name: 'Pagados', value: summary.paid },
-  ];
+  ] : [];
+
+  const cardStyle = {
+    background: '#fff',
+    padding: '1rem',
+    borderRadius: '8px',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+    flex: '1',
+    minWidth: '150px'
+  };
+
+  if (!summary && !devices.length) return <div><h2>Dashboard</h2><p>Sin datos</p></div>;
 
   return (
     <div>
-      <h2>Contratos</h2>
-      <BarChart width={400} height={250} data={data}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="name" />
-        <YAxis allowDecimals={false} />
-        <Tooltip />
-        <Legend />
-        <Bar dataKey="value" fill="#8884d8" />
-      </BarChart>
+      <h2>Dashboard</h2>
+      <div style={{display:'flex', gap:'1rem', marginBottom:'1rem', flexWrap:'wrap'}}>
+        <motion.div style={cardStyle} initial={{opacity:0, y:10}} animate={{opacity:1, y:0}}>
+          <h3>Dispositivos Activos</h3>
+          <p>{devices.length}</p>
+        </motion.div>
+        <motion.div style={cardStyle} initial={{opacity:0, y:10}} animate={{opacity:1, y:0}} transition={{delay:0.1}}>
+          <h3>Alertas</h3>
+          <p>{alerts.length}</p>
+        </motion.div>
+        <motion.div style={cardStyle} initial={{opacity:0, y:10}} animate={{opacity:1, y:0}} transition={{delay:0.2}}>
+          <h3>Pagos Vencidos</h3>
+          <p>{summary?.overdue || 0}</p>
+        </motion.div>
+      </div>
+      {summary && (
+        <motion.div initial={{opacity:0}} animate={{opacity:1}}>
+          <BarChart width={400} height={250} data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis allowDecimals={false} />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="value" fill="#8884d8" isAnimationActive={true} />
+          </BarChart>
+        </motion.div>
+      )}
     </div>
   );
 }

--- a/server/admin-frontend/index.html
+++ b/server/admin-frontend/index.html
@@ -89,6 +89,7 @@
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+  <script src="https://unpkg.com/framer-motion/dist/framer-motion.umd.js"></script>
     <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
     <script type="text/babel" src="admin/dashboard/index.jsx"></script>
     <script type="text/babel" src="admin/clients/index.jsx"></script>

--- a/server/admin-frontend/package-lock.json
+++ b/server/admin-frontend/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "admin-frontend",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "recharts": "^2.10.0",
+        "framer-motion": "^10.16.4"
+      }
     }
   }
 }

--- a/server/admin-frontend/package.json
+++ b/server/admin-frontend/package.json
@@ -7,5 +7,9 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "recharts": "^2.10.0",
+    "framer-motion": "^10.16.4"
+  }
 }

--- a/server/client-frontend/app.jsx
+++ b/server/client-frontend/app.jsx
@@ -1,4 +1,6 @@
 const { useState, useEffect } = React;
+const { BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } = Recharts;
+const { motion } = window.framerMotion || {};
 
 const API_BASE = '/api/client';
 
@@ -16,14 +18,60 @@ async function apiFetch(path, options = {}) {
 
 function Dashboard() {
   const [devices, setDevices] = useState([]);
+  const [summary, setSummary] = useState(null);
   useEffect(() => {
     apiFetch('/devices').then(setDevices).catch(console.error);
+    apiFetch('/contracts/summary').then(setSummary).catch(() => setSummary(null));
   }, []);
-  const total = devices.length;
+  const alerts = [];
+  devices.forEach(d => {
+    const s = d.status || {};
+    if (s.battery && s.battery < 20) alerts.push('b');
+    if (s.rootAttempt) alerts.push('r');
+    if (s.wipeDetected) alerts.push('w');
+    if (s.bootloaderTampered) alerts.push('t');
+  });
+  const data = summary ? [
+    { name: 'Total', value: summary.total },
+    { name: 'Vencidos', value: summary.overdue },
+    { name: 'Pagados', value: summary.paid }
+  ] : [];
+  const cardStyle = {
+    background: '#fff',
+    padding: '1rem',
+    borderRadius: '8px',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+    flex: '1',
+    minWidth: '150px'
+  };
   return (
     <div>
       <h2>Dashboard</h2>
-      <p>Dispositivos registrados: {total}</p>
+      <div style={{display:'flex', gap:'1rem', marginBottom:'1rem', flexWrap:'wrap'}}>
+        <motion.div style={cardStyle} initial={{opacity:0, y:10}} animate={{opacity:1, y:0}}>
+          <h3>Dispositivos Activos</h3>
+          <p>{devices.length}</p>
+        </motion.div>
+        <motion.div style={cardStyle} initial={{opacity:0, y:10}} animate={{opacity:1, y:0}} transition={{delay:0.1}}>
+          <h3>Alertas</h3>
+          <p>{alerts.length}</p>
+        </motion.div>
+        <motion.div style={cardStyle} initial={{opacity:0, y:10}} animate={{opacity:1, y:0}} transition={{delay:0.2}}>
+          <h3>Pagos Vencidos</h3>
+          <p>{summary?.overdue || 0}</p>
+        </motion.div>
+      </div>
+      {summary && (
+        <motion.div initial={{opacity:0}} animate={{opacity:1}}>
+          <BarChart width={400} height={250} data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis allowDecimals={false} />
+            <Tooltip />
+            <Bar dataKey="value" fill="#8884d8" isAnimationActive={true} />
+          </BarChart>
+        </motion.div>
+      )}
     </div>
   );
 }

--- a/server/client-frontend/index.html
+++ b/server/client-frontend/index.html
@@ -18,6 +18,8 @@
   <div id="root"></div>
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+  <script src="https://unpkg.com/framer-motion/dist/framer-motion.umd.js"></script>
   <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   <script type="text/babel" src="app.jsx"></script>
 </body>

--- a/server/client-frontend/package-lock.json
+++ b/server/client-frontend/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "client-frontend",
       "version": "1.0.0",
-      "license": "ISC"
+      "license": "ISC",
+      "dependencies": {
+        "recharts": "^2.10.0",
+        "framer-motion": "^10.16.4"
+      }
     }
   }
 }

--- a/server/client-frontend/package.json
+++ b/server/client-frontend/package.json
@@ -7,5 +7,9 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "recharts": "^2.10.0",
+    "framer-motion": "^10.16.4"
+  }
 }


### PR DESCRIPTION
## Summary
- add Recharts and Framer Motion dependencies to admin and client frontends
- show KPI cards and animated bar charts on dashboards
- load visualization and animation libraries via script tags

## Testing
- `npm test` (admin-frontend)
- `npm test` (client-frontend)


------
https://chatgpt.com/codex/tasks/task_b_6898d103ea8c8320adb39b49a265ff81