### PR TITLE
Restrict one user per store

### DIFF
--- a/server/Servidor/models.py
+++ b/server/Servidor/models.py
@@ -108,7 +108,7 @@ class User(Base):
     username = Column(String, unique=True, nullable=False)
     password_hash = Column(String, nullable=False)
     role = Column(String, nullable=False)
-    store_id = Column(Integer, ForeignKey("stores.id"))
+    store_id = Column(Integer, ForeignKey("stores.id"), unique=True)
 
     store = relationship("Store", back_populates="users")
     clients = relationship("Client", back_populates="user", cascade="all, delete-orphan")

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -272,6 +272,9 @@ def api_users():
         store = db.query(Store).filter_by(id=store_id).first()
         if not store:
             return jsonify({'success': False, 'message': 'Store not found'}), 404
+        existing = db.query(User).filter_by(store_id=store_id).first()
+        if existing:
+            return jsonify({'success': False, 'message': 'Store already has a user'}), 400
         user = User(username=username, role=role, store_id=store_id)
         user.set_password(password)
         db.add(user)

--- a/server/admin-frontend/admin/clients/index.jsx
+++ b/server/admin-frontend/admin/clients/index.jsx
@@ -7,6 +7,8 @@ function StoreUserManager() {
   const [storeName, setStoreName] = useState('');
   const [users, setUsers] = useState([]);
   const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [storeId, setStoreId] = useState('');
   const [perms, setPerms] = useState([]);
   const [editing, setEditing] = useState(null);
   const [editDomain, setEditDomain] = useState('');
@@ -46,11 +48,12 @@ function StoreUserManager() {
   function createUser(e) {
     e.preventDefault();
     if (!window.apiFetch) return;
-    const body = { username, permissions: perms };
+    if (!storeId || users.some(u => u.store_id === Number(storeId))) return;
+    const body = { username, password, store_id: Number(storeId), permissions: perms };
     window.apiFetch('/api/users', { method: 'POST', body: JSON.stringify(body) })
       .then(u => setUsers([...users, u]))
       .catch(() => {})
-      .finally(() => { setUsername(''); setPerms([]); });
+      .finally(() => { setUsername(''); setPassword(''); setStoreId(''); setPerms([]); });
   }
 
   const toggle = (p) => {
@@ -155,7 +158,12 @@ function StoreUserManager() {
 
       <h2>Usuarios</h2>
       <form onSubmit={createUser} style={{ marginBottom: '1rem' }}>
+        <select value={storeId} onChange={e => setStoreId(e.target.value)}>
+          <option value="">Tienda</option>
+          {stores.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+        </select>
         <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Usuario" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Contraseña" />
         <div>
           {PERMISSIONS.map(p => (
             <label key={p} style={{ marginRight: '0.5rem' }}>
@@ -163,11 +171,11 @@ function StoreUserManager() {
             </label>
           ))}
         </div>
-        <button type="submit">Crear</button>
+        <button type="submit" disabled={!storeId || users.some(u => u.store_id === Number(storeId))}>Crear</button>
       </form>
       <ul>
         {users.map(u => (
-          <li key={u.id}>{u.username} - {u.permissions.join(', ')}</li>
+          <li key={u.id}>{u.username} - tienda {u.store_id}</li>
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- limit `User` model to a single account per store
- block user creation via API when a store already has an account
- disable admin UI user creation when the selected store already has a user

## Testing
- `pytest tests` *(fails: sqlite3.OperationalError: attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_b_6898d37ddb98832081f298de93c37955