### PR TITLE
Agrega manual técnico y enlaces de documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ curl -X POST https://mi-servidor/api/devices/42/lock \
 - Deshabilita o protege el endpoint `/install` una vez finalizada la configuración.
 - Limita los intentos de inicio de sesión para mitigar fuerza bruta.
 
+## Documentación adicional
+
+- [Manual técnico completo](docs/manual_tecnico.pdf)
+
 ## Licencia
 
 Este proyecto se distribuye bajo los términos de la licencia MIT. Consulta el archivo `LICENSE` para más información.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 La documentación completa de BizonMDM se encuentra en `documentation.html`. Abre este archivo en tu navegador para obtener una guía detallada de instalación y uso.
 
+## Manual técnico completo
+
+Descarga el [manual técnico](manual_tecnico.pdf) con la arquitectura detallada de la plataforma.
+
 ## Novedades
 
 - La carpeta `DEMO/` ahora utiliza un estilo unificado para el panel administrativo y el del cliente.

--- a/docs/manual_tecnico.md
+++ b/docs/manual_tecnico.md
@@ -1,0 +1,125 @@
+# Manual técnico de BizonMDM
+
+## Visión general de la plataforma
+
+BizonMDM es un sistema de gestión de dispositivos móviles compuesto por un
+backend en **Flask**, dos interfaces web escritas en **React** y una
+aplicación **Android** desarrollada en **Kotlin**. A continuación se
+describe de forma detallada la arquitectura de cada componente.
+
+## Backend Flask (`server/Servidor`)
+
+### Organización de archivos
+
+El directorio `server/Servidor` contiene la API REST principal:
+
+- `server.py` inicializa la aplicación Flask, registra rutas y puede
+  ejecutarse con los parámetros `BIZON_HOST`, `BIZON_PORT` y `JWT_SECRET`.
+- `models.py` define los modelos de base de datos con SQLAlchemy.
+- `configs/` almacena plantillas de configuración y la plantilla del
+  archivo `.env` generado durante la instalación.
+- `alembic/` y `alembic.ini` gestionan las migraciones de esquema mediante
+  Alembic.
+
+Además del módulo `Servidor`, la carpeta `server/` incluye paquetes
+especializados (`admin`, `alerts`, `client`, `device`, `documents`,
+`financing`, `tasks`) que encapsulan la lógica del dominio y exponen
+blueprints de Flask para ampliar la API.
+
+### Flujo de peticiones y seguridad
+
+El servicio expone endpoints para registrar dispositivos, consultar su
+estado, enviar comandos y recuperar logs. La autenticación se realiza con
+**JSON Web Tokens (JWT)** firmados con la variable de entorno
+`JWT_SECRET`. Los endpoints administrativos verifican el rol del usuario
+antes de ejecutar cualquier acción.
+
+Las peticiones se persisten en una base de datos SQL mediante
+**SQLAlchemy**. Las migraciones se controlan con **Alembic**, permitiendo
+actualizar el esquema sin perder datos.
+
+### Integraciones externas
+
+- **Firebase Cloud Messaging (FCM):** si se define `FCM_SERVER_KEY` el
+  servidor envía notificaciones push cuando se encola un comando.
+- **Provisión mediante QR:** el endpoint `/provisioning/qr/<deviceId>`
+  genera códigos QR para aprovisionamiento sin intervención manual.
+
+## Módulos React (`admin-frontend` y `client-frontend`)
+
+Las interfaces web viven en `server/admin-frontend` y
+`server/client-frontend` respectivamente. Cada módulo contiene:
+
+- `index.html` que carga React desde CDN y monta la aplicación.
+- `app.jsx` con los componentes principales escritos con la API de
+  funciones (`useState`, `useEffect`).
+- `package.json` con dependencias ligeras como `recharts` para gráficas y
+  `framer-motion` para animaciones. No se requiere un bundler complejo;
+  los archivos JSX se transpilan de forma sencilla para producción.
+
+### Panel de administración
+
+`admin-frontend/app.jsx` utiliza un helper `apiFetch` que añade el token
+JWT almacenado en `localStorage` y consume endpoints como `/devices` o
+`/api/status`. Presenta un tablero con el listado de dispositivos y un
+indicador de salud del servidor.
+
+### Panel de cliente
+
+`client-frontend/app.jsx` ofrece una interfaz simplificada para que los
+usuarios finales consulten el estado de sus propios dispositivos y
+reciban notificaciones visuales de los comandos enviados.
+
+Ambos módulos se sirven como archivos estáticos desde Flask y pueden
+recompilarse con `npm install` seguido de `npm run build` en sus
+respectivos directorios.
+
+## Aplicación Android en Kotlin (`mobile/app`)
+
+### Estructura general
+
+El proyecto Android utiliza Gradle con flavors `dev` y `prod` que definen
+la URL del backend mediante `BuildConfig.BASE_URL`. Dentro de
+`mobile/app/src/main/java/com/example/mdmjive/` se encuentran los módulos
+principales:
+
+- **Servicios:** `MDMService` mantiene un servicio en primer plano con una
+  notificación persistente y programa tareas periódicas con `WorkManager`.
+  `FCMService` maneja los mensajes push de Firebase.
+- **Receivers:** `MDMDeviceAdminReceiver` y `SecurityEventReceiver`
+  administran eventos del `DevicePolicyManager` y del sistema.
+- **Núcleo y utilidades:** `MDMCore` centraliza la lógica de negocio,
+  mientras que `TokenManager`, `SecurityUtils` y `QRConfig` proveen
+  funcionalidades de soporte.
+- **Persistencia:** `LogDatabase` implementa una base de datos local con
+  **Room** para almacenar eventos, políticas y auditorías.
+- **Comunicación remota:** `ApiService` usa **Retrofit** para interactuar
+  con la API del servidor (`devices/register`, `client/logs`,
+  `client/commands`, etc.).
+- **Seguridad:** `SecurityChecker`, `DeviceCertificationManager` y
+  `PolicyManager` verifican el estado del dispositivo, aplican políticas y
+  cifran información sensible mediante `EncryptionManager`.
+- **Tareas en segundo plano:** `SyncWorker` sincroniza periódicamente el
+  estado y los logs con el backend.
+
+### Flujo de operación
+
+Al iniciar el dispositivo se levanta `MDMService`, que a su vez programa
+`SyncWorker` y monitoriza el `DevicePolicyManager`. Los eventos de
+seguridad se registran en `LogDatabase` y pueden enviarse al servidor
+cuando haya conectividad. Los comandos recibidos vía FCM se delegan a
+`CommandExecutor`, que aplica acciones como bloqueo o borrado remoto.
+
+## Despliegue y consideraciones finales
+
+- **Servidor:** puede ejecutarse directamente con `python
+  server/Servidor/server.py` o mediante `docker-compose` para incluir la
+  base de datos y el panel web.
+- **Frontends:** tras cualquier modificación en los archivos JSX, ejecutar
+  `npm install` y `npm run build` dentro de cada módulo para generar la
+  versión optimizada.
+- **Aplicación móvil:** compilar con `./gradlew assembleDevDebug` o
+  `./gradlew assembleProdRelease` según el entorno deseado.
+
+Este manual proporciona una visión técnica integral para desarrolladores
+y administradores que necesiten comprender o extender BizonMDM.

--- a/docs/manual_tecnico.pdf
+++ b/docs/manual_tecnico.pdf
@@ -1,0 +1,283 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 7406 >>
+stream
+BT /F1 12 Tf 50 750 Td
+(# Manual tcnico de BizonMDM) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(## Visin general de la plataforma) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(BizonMDM es un sistema de gestin de dispositivos mviles compuesto por un) Tj
+0 -14 Td
+(backend en **Flask**, dos interfaces web escritas en **React** y una) Tj
+0 -14 Td
+(aplicacin **Android** desarrollada en **Kotlin**. A continuacin se) Tj
+0 -14 Td
+(describe de forma detallada la arquitectura de cada componente.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(## Backend Flask \(`server/Servidor`\)) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(### Organizacin de archivos) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(El directorio `server/Servidor` contiene la API REST principal:) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(- `server.py` inicializa la aplicacin Flask, registra rutas y puede) Tj
+0 -14 Td
+(  ejecutarse con los parmetros `BIZON_HOST`, `BIZON_PORT` y `JWT_SECRET`.) Tj
+0 -14 Td
+(- `models.py` define los modelos de base de datos con SQLAlchemy.) Tj
+0 -14 Td
+(- `configs/` almacena plantillas de configuracin y la plantilla del) Tj
+0 -14 Td
+(  archivo `.env` generado durante la instalacin.) Tj
+0 -14 Td
+(- `alembic/` y `alembic.ini` gestionan las migraciones de esquema mediante) Tj
+0 -14 Td
+(  Alembic.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(Adems del mdulo `Servidor`, la carpeta `server/` incluye paquetes) Tj
+0 -14 Td
+(especializados \(`admin`, `alerts`, `client`, `device`, `documents`,) Tj
+0 -14 Td
+(`financing`, `tasks`\) que encapsulan la lgica del dominio y exponen) Tj
+0 -14 Td
+(blueprints de Flask para ampliar la API.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(### Flujo de peticiones y seguridad) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(El servicio expone endpoints para registrar dispositivos, consultar su) Tj
+0 -14 Td
+(estado, enviar comandos y recuperar logs. La autenticacin se realiza con) Tj
+0 -14 Td
+(**JSON Web Tokens \(JWT\)** firmados con la variable de entorno) Tj
+0 -14 Td
+(`JWT_SECRET`. Los endpoints administrativos verifican el rol del usuario) Tj
+0 -14 Td
+(antes de ejecutar cualquier accin.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(Las peticiones se persisten en una base de datos SQL mediante) Tj
+0 -14 Td
+(**SQLAlchemy**. Las migraciones se controlan con **Alembic**, permitiendo) Tj
+0 -14 Td
+(actualizar el esquema sin perder datos.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(### Integraciones externas) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(- **Firebase Cloud Messaging \(FCM\):** si se define `FCM_SERVER_KEY` el) Tj
+0 -14 Td
+(  servidor enva notificaciones push cuando se encola un comando.) Tj
+0 -14 Td
+(- **Provisin mediante QR:** el endpoint `/provisioning/qr/<deviceId>`) Tj
+0 -14 Td
+(  genera cdigos QR para aprovisionamiento sin intervencin manual.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(## Mdulos React \(`admin-frontend` y `client-frontend`\)) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(Las interfaces web viven en `server/admin-frontend` y) Tj
+0 -14 Td
+(`server/client-frontend` respectivamente. Cada mdulo contiene:) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(- `index.html` que carga React desde CDN y monta la aplicacin.) Tj
+0 -14 Td
+(- `app.jsx` con los componentes principales escritos con la API de) Tj
+0 -14 Td
+(  funciones \(`useState`, `useEffect`\).) Tj
+0 -14 Td
+(- `package.json` con dependencias ligeras como `recharts` para grficas y) Tj
+0 -14 Td
+(  `framer-motion` para animaciones. No se requiere un bundler complejo;) Tj
+0 -14 Td
+(  los archivos JSX se transpilan de forma sencilla para produccin.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(### Panel de administracin) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(`admin-frontend/app.jsx` utiliza un helper `apiFetch` que aade el token) Tj
+0 -14 Td
+(JWT almacenado en `localStorage` y consume endpoints como `/devices` o) Tj
+0 -14 Td
+(`/api/status`. Presenta un tablero con el listado de dispositivos y un) Tj
+0 -14 Td
+(indicador de salud del servidor.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(### Panel de cliente) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(`client-frontend/app.jsx` ofrece una interfaz simplificada para que los) Tj
+0 -14 Td
+(usuarios finales consulten el estado de sus propios dispositivos y) Tj
+0 -14 Td
+(reciban notificaciones visuales de los comandos enviados.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(Ambos mdulos se sirven como archivos estticos desde Flask y pueden) Tj
+0 -14 Td
+(recompilarse con `npm install` seguido de `npm run build` en sus) Tj
+0 -14 Td
+(respectivos directorios.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(## Aplicacin Android en Kotlin \(`mobile/app`\)) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(### Estructura general) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(El proyecto Android utiliza Gradle con flavors `dev` y `prod` que definen) Tj
+0 -14 Td
+(la URL del backend mediante `BuildConfig.BASE_URL`. Dentro de) Tj
+0 -14 Td
+(`mobile/app/src/main/java/com/example/mdmjive/` se encuentran los mdulos) Tj
+0 -14 Td
+(principales:) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(- **Servicios:** `MDMService` mantiene un servicio en primer plano con una) Tj
+0 -14 Td
+(  notificacin persistente y programa tareas peridicas con `WorkManager`.) Tj
+0 -14 Td
+(  `FCMService` maneja los mensajes push de Firebase.) Tj
+0 -14 Td
+(- **Receivers:** `MDMDeviceAdminReceiver` y `SecurityEventReceiver`) Tj
+0 -14 Td
+(  administran eventos del `DevicePolicyManager` y del sistema.) Tj
+0 -14 Td
+(- **Ncleo y utilidades:** `MDMCore` centraliza la lgica de negocio,) Tj
+0 -14 Td
+(  mientras que `TokenManager`, `SecurityUtils` y `QRConfig` proveen) Tj
+0 -14 Td
+(  funcionalidades de soporte.) Tj
+0 -14 Td
+(- **Persistencia:** `LogDatabase` implementa una base de datos local con) Tj
+0 -14 Td
+(  **Room** para almacenar eventos, polticas y auditoras.) Tj
+0 -14 Td
+(- **Comunicacin remota:** `ApiService` usa **Retrofit** para interactuar) Tj
+0 -14 Td
+(  con la API del servidor \(`devices/register`, `client/logs`,) Tj
+0 -14 Td
+(  `client/commands`, etc.\).) Tj
+0 -14 Td
+(- **Seguridad:** `SecurityChecker`, `DeviceCertificationManager` y) Tj
+0 -14 Td
+(  `PolicyManager` verifican el estado del dispositivo, aplican polticas y) Tj
+0 -14 Td
+(  cifran informacin sensible mediante `EncryptionManager`.) Tj
+0 -14 Td
+(- **Tareas en segundo plano:** `SyncWorker` sincroniza peridicamente el) Tj
+0 -14 Td
+(  estado y los logs con el backend.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(### Flujo de operacin) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(Al iniciar el dispositivo se levanta `MDMService`, que a su vez programa) Tj
+0 -14 Td
+(`SyncWorker` y monitoriza el `DevicePolicyManager`. Los eventos de) Tj
+0 -14 Td
+(seguridad se registran en `LogDatabase` y pueden enviarse al servidor) Tj
+0 -14 Td
+(cuando haya conectividad. Los comandos recibidos va FCM se delegan a) Tj
+0 -14 Td
+(`CommandExecutor`, que aplica acciones como bloqueo o borrado remoto.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(## Despliegue y consideraciones finales) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(- **Servidor:** puede ejecutarse directamente con `python) Tj
+0 -14 Td
+(  server/Servidor/server.py` o mediante `docker-compose` para incluir la) Tj
+0 -14 Td
+(  base de datos y el panel web.) Tj
+0 -14 Td
+(- **Frontends:** tras cualquier modificacin en los archivos JSX, ejecutar) Tj
+0 -14 Td
+(  `npm install` y `npm run build` dentro de cada mdulo para generar la) Tj
+0 -14 Td
+(  versin optimizada.) Tj
+0 -14 Td
+(- **Aplicacin mvil:** compilar con `./gradlew assembleDevDebug` o) Tj
+0 -14 Td
+(  `./gradlew assembleProdRelease` segn el entorno deseado.) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(Este manual proporciona una visin tcnica integral para desarrolladores) Tj
+0 -14 Td
+(y administradores que necesiten comprender o extender BizonMDM.) Tj
+0 -14 Td
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000007699 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+7769
+%%EOF


### PR DESCRIPTION
## Summary
- Añade `manual_tecnico.md` con la arquitectura del backend Flask, frontends React y app Android.
- Genera `manual_tecnico.pdf` a partir del Markdown y lo enlaza en `docs/README.md` y en el README principal.

## Testing
- `pytest` *(falla: attempt to write a readonly database)*
- `npm test --prefix server/admin-frontend`
- `npm test --prefix server/client-frontend`


------
https://chatgpt.com/codex/tasks/task_b_6898d62dcef883209a87ab6c58293bec