### PR TITLE
docs: add technical manual link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ BizonMDM es una plataforma de Mobile Device Management (MDM) de código abierto.
   - `docker-compose.yml`: ejemplo de despliegue con contenedores.
   - `install.py` e `instalacion_bizonmdm.html`: utilidades para la instalación.
   - `SUBDOMAIN_SETUP.md`: ejemplo de configuración de NGINX/Apache para servir varios subdominios.
-- `docs/`: documentación adicional incluyendo `documentation.html`.
+- `docs/`: documentación adicional incluyendo `documentation.html` y el [Manual técnico](https://docs.google.com/document/d/1rTvD54LBkILeUw0XYt5bMTrlQct1lF9NmRNHJtniKrk/edit?usp=sharing).
 
 ### Configurar la URL del servidor en la app móvil
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 La documentación completa de BizonMDM se encuentra en `documentation.html`. Abre este archivo en tu navegador para obtener una guía detallada de instalación y uso.
 
+También puedes consultar el [Manual técnico](https://docs.google.com/document/d/1rTvD54LBkILeUw0XYt5bMTrlQct1lF9NmRNHJtniKrk/edit?usp=sharing) para información adicional.
+
 ## Novedades
 
 - La carpeta `DEMO/` ahora utiliza un estilo unificado para el panel administrativo y el del cliente.


### PR DESCRIPTION
## Summary
- add technical manual link to repository documentation

## Testing
- `pytest` *(fails: sqlite3.OperationalError: attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_b_6898dda954688320826ce3f276662bdd