### PR TITLE
chore: ignore Next and upload directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ __pycache__/
 # Frontend
 node_modules/
 dist/
+next/
+public/uploads/
 


### PR DESCRIPTION
## Summary
- ignore `next/` and `public/uploads/` directories to avoid committing build outputs and uploaded files

## Testing
- `npm test --prefix server/admin-frontend`
- `pytest` *(fails: attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_b_68a2a0a4df608320ac466e34d521899e