### PR TITLE
chore: ignore default Next.js build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,6 @@ __pycache__/
 # Frontend
 node_modules/
 dist/
-next/
+.next/
 public/uploads/
 


### PR DESCRIPTION
## Summary
- ignore default Next.js build directory by adding `.next/` to `.gitignore`

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a2a200fdf88320af47b3640517727f