### PR TITLE
Secure document review routes with JWT admin check

### DIFF
--- a/server/admin/auth.py
+++ b/server/admin/auth.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from functools import wraps
+from flask import jsonify
+from flask_jwt_extended import verify_jwt_in_request, get_jwt
+
+
+def require_admin(func):
+    """Decorator that enforces presence of a valid admin JWT token."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            verify_jwt_in_request()
+            claims = get_jwt()
+        except Exception:  # noqa: BLE001
+            return jsonify({"success": False, "message": "Unauthorized"}), 401
+        if claims.get("role") != "admin":
+            return jsonify({"success": False, "message": "Forbidden"}), 403
+        return func(*args, **kwargs)
+
+    return wrapper
+
+__all__ = ["require_admin"]

--- a/server/admin/documents/review.py
+++ b/server/admin/documents/review.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from flask import Blueprint, jsonify
 
 from documents.storage import list_pending, set_status
+from ..auth import require_admin
 
 bp = Blueprint("document_review", __name__, url_prefix="/documents")
 
 
 @bp.route("/pending", methods=["GET"])
+@require_admin
 def pending():
     """Lista los documentos que aún no han sido revisados."""
 
@@ -21,6 +23,7 @@ def pending():
 
 
 @bp.route("/approve/<doc_id>", methods=["POST"])
+@require_admin
 def approve(doc_id: str):
     """Aprueba un documento."""
 
@@ -30,6 +33,7 @@ def approve(doc_id: str):
 
 
 @bp.route("/reject/<doc_id>", methods=["POST"])
+@require_admin
 def reject(doc_id: str):
     """Rechaza un documento."""
 

--- a/server/admin/tests/test_documents_review_auth.py
+++ b/server/admin/tests/test_documents_review_auth.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import unittest
+
+from flask import Flask
+from flask_jwt_extended import JWTManager, create_access_token
+import werkzeug
+
+# Ensure modules in server directory can be imported
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from admin.documents.review import bp  # type: ignore  # noqa: E402
+
+
+class ReviewAuthTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.config["JWT_SECRET_KEY"] = "testsecret"
+        JWTManager(self.app)
+        if not hasattr(werkzeug, "__version__"):
+            werkzeug.__version__ = "3"  # pragma: no cover
+        self.app.register_blueprint(bp)
+        self.client = self.app.test_client()
+
+    def _user_token(self):
+        with self.app.app_context():
+            return create_access_token("user1", additional_claims={"role": "user"})
+
+    def test_pending_requires_admin(self):
+        resp = self.client.get("/documents/pending")
+        self.assertEqual(resp.status_code, 401)
+        token = self._user_token()
+        resp = self.client.get(
+            "/documents/pending", headers={"Authorization": f"Bearer {token}"}
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_modify_requires_admin(self):
+        for endpoint in ["/documents/approve/1", "/documents/reject/1"]:
+            resp = self.client.post(endpoint)
+            self.assertEqual(resp.status_code, 401)
+            token = self._user_token()
+            resp = self.client.post(
+                endpoint, headers={"Authorization": f"Bearer {token}"}
+            )
+            self.assertEqual(resp.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add reusable `require_admin` decorator for JWT-based admin authorization
- Protect document review routes with `@require_admin`
- Test that document review endpoints reject missing or non-admin tokens

## Testing
- `pytest server/admin/tests/test_documents_review_auth.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a2ab79942c8320b1e30b2a59309bc7