### PR TITLE
Persist permissions in database with cache

### DIFF
--- a/server/admin/permissions/models.py
+++ b/server/admin/permissions/models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from sqlalchemy import Column, Integer, String, UniqueConstraint, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DEFAULT_DB_URL = "sqlite:///permissions.db"
+DB_URL = os.getenv("DATABASE_URL", DEFAULT_DB_URL)
+engine = create_engine(DB_URL, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+Base = declarative_base()
+
+
+class Permission(Base):
+    """Permiso de acción asociado a una entidad."""
+
+    __tablename__ = "permissions"
+
+    id = Column(Integer, primary_key=True)
+    entity_type = Column(String, nullable=False)
+    entity_id = Column(String, nullable=False)
+    action = Column(String, nullable=False)
+
+    __table_args__ = (UniqueConstraint("entity_type", "entity_id", "action"),)
+
+
+def init_db(drop: bool = False) -> None:
+    """Inicializa la base de datos de permisos."""
+
+    if drop:
+        Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+
+
+__all__ = ["Permission", "SessionLocal", "init_db"]

--- a/server/admin/permissions/views.py
+++ b/server/admin/permissions/views.py
@@ -1,21 +1,26 @@
 """Vistas para gestionar permisos de acciones sobre dispositivos.
 
-Proporciona un pequeño formulario (endpoint JSON) para habilitar o
-inhabilitar acciones por tienda o contrato. La información se almacena en
-memoria para simplificar el ejemplo.
+Los permisos se almacenan en una tabla de base de datos. Opcionalmente se
+cachean en memoria para acelerar las consultas. Cada vez que se actualizan los
+permisos de una entidad, la caché correspondiente se invalida.
 """
 
 from __future__ import annotations
 
+import os
 from typing import Dict, Set, Tuple
+
 from flask import Blueprint, jsonify, request
 
-from device.permissions import AVAILABLE_ACTIONS
+from ...device.permissions import AVAILABLE_ACTIONS
+from .models import Permission, SessionLocal, init_db
 
 bp = Blueprint("permissions", __name__, url_prefix="/permissions")
 
-# Almacén en memoria: {(tipo, id): {acciones}}
-_ALLOWED_ACTIONS: Dict[Tuple[str, str], Set[str]] = {}
+CACHE_ENABLED = os.getenv("PERMISSIONS_CACHE", "1") == "1"
+_cache: Dict[Tuple[str, str], Set[str]] = {}
+
+init_db()
 
 
 def _key(entity_type: str, entity_id: str) -> Tuple[str, str]:
@@ -43,14 +48,40 @@ def configure_permissions():
             jsonify({"success": False, "invalid": invalid}),
             400,
         )
-    _ALLOWED_ACTIONS[_key(entity_type, entity_id)] = set(actions)
+    with SessionLocal() as session:
+        session.query(Permission).filter_by(
+            entity_type=entity_type, entity_id=str(entity_id)
+        ).delete()
+        session.add_all(
+            [
+                Permission(
+                    entity_type=entity_type, entity_id=str(entity_id), action=a
+                )
+                for a in actions
+            ]
+        )
+        session.commit()
+    if CACHE_ENABLED:
+        _cache.pop(_key(entity_type, entity_id), None)
     return jsonify({"success": True})
 
 
 def get_allowed_actions(entity_type: str, entity_id: str) -> Set[str]:
     """Obtiene las acciones permitidas para la entidad indicada."""
 
-    return _ALLOWED_ACTIONS.get(_key(entity_type, entity_id), set())
+    key = _key(entity_type, entity_id)
+    if CACHE_ENABLED and key in _cache:
+        return _cache[key]
+    with SessionLocal() as session:
+        rows = (
+            session.query(Permission.action)
+            .filter_by(entity_type=entity_type, entity_id=str(entity_id))
+            .all()
+        )
+        actions = {r[0] for r in rows}
+    if CACHE_ENABLED:
+        _cache[key] = actions
+    return actions
 
 
 __all__ = ["bp", "get_allowed_actions"]

--- a/server/admin/tests/test_permissions.py
+++ b/server/admin/tests/test_permissions.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib
+import os
+
+from flask import Flask
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.insert(0, ROOT)
+sys.modules.pop("server", None)
+sys.modules.pop("server.admin", None)
+
+
+def test_permissions_persist_and_cache_invalidation(tmp_path, monkeypatch):
+    db_path = tmp_path / "perm.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    sys.modules.pop("server", None)
+    sys.modules.pop("server.admin", None)
+
+    # reload modules to ensure they use the temp database
+
+    # Reload modules to pick up the new DATABASE_URL
+    from server.admin.permissions import models
+    importlib.reload(models)
+    models.init_db(drop=True)
+    from server.admin.permissions import views
+    importlib.reload(views)
+
+    app = Flask(__name__)
+    app.register_blueprint(views.bp)
+    import werkzeug
+    if not hasattr(werkzeug, "__version__"):
+        werkzeug.__version__ = "3"
+    client = app.test_client()
+
+    resp = client.post(
+        "/permissions/configure",
+        json={"type": "store", "id": "1", "actions": ["lock"]},
+    )
+    assert resp.status_code == 200
+    assert views.get_allowed_actions("store", "1") == {"lock"}
+
+    resp = client.post(
+        "/permissions/configure",
+        json={"type": "store", "id": "1", "actions": ["gps"]},
+    )
+    assert resp.status_code == 200
+    assert views.get_allowed_actions("store", "1") == {"gps"}


### PR DESCRIPTION
## Summary
- Add SQLAlchemy `Permission` model to store allowed actions per entity
- Query permissions from database with optional in-memory cache and invalidation
- Test permission persistence and cache invalidation

## Testing
- `pytest server/admin/tests/test_permissions.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'server.admin'; 'server' is not a package, plus database OperationalError)*

------
https://chatgpt.com/codex/tasks/task_b_68a2ad159c988320ab70d0cf8fddc75f