### PR TITLE
Fail startup without JWT_SECRET and document required env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Define variables antes de levantar los contenedores:
 - `DATABASE_URL`: cadena de conexión a la base de datos. **Obligatoria**.
 - `BIZON_HOST`: dirección en la que el servidor escucha (opcional, por defecto `0.0.0.0`).
 - `BIZON_PORT`: puerto interno del servidor (opcional, por defecto `5000`).
-- `JWT_SECRET`: clave para firmar tokens JWT.
+- `JWT_SECRET`: clave para firmar tokens JWT. **Obligatoria**.
 - `FCM_SERVER_KEY`: clave de Firebase Cloud Messaging para notificaciones.
 
 ### Detener o eliminar contenedores

--- a/server/Servidor/server.py
+++ b/server/Servidor/server.py
@@ -65,9 +65,9 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
 )
-
-if JWT_SECRET:
-    app.config["JWT_SECRET_KEY"] = JWT_SECRET
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is required")
+app.config["JWT_SECRET_KEY"] = JWT_SECRET
 jwt = JWTManager(app)
 
 

--- a/server/Servidor/tests/test_missing_jwt_secret.py
+++ b/server/Servidor/tests/test_missing_jwt_secret.py
@@ -1,0 +1,30 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_server_requires_jwt_secret(tmp_path):
+    """Importing the server without JWT_SECRET should fail."""
+    env = os.environ.copy()
+    env.pop("JWT_SECRET", None)
+    env["DATABASE_URL"] = f"sqlite:///{tmp_path/'test.db'}"
+    env["SKIP_ALEMBIC"] = "1"
+    base = Path(__file__).resolve().parents[1]
+    dotenv = base / ".env"
+    backup = base / ".env.bak"
+    if dotenv.exists():
+        dotenv.rename(backup)
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", "import server"],
+            cwd=base,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        if backup.exists():
+            backup.rename(dotenv)
+    assert proc.returncode != 0
+    assert "JWT_SECRET" in proc.stderr

--- a/server/Servidor/tests/test_server.py
+++ b/server/Servidor/tests/test_server.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 # Configure database and token before importing the server
 DB_FD, DB_PATH = tempfile.mkstemp()
+os.close(DB_FD)
 os.environ['DATABASE_URL'] = f'sqlite:///{DB_PATH}'
 os.environ['JWT_SECRET'] = 'testsecret'
 os.environ['SKIP_ALEMBIC'] = '1'
@@ -20,7 +21,6 @@ from models import Admin, Device, Client, User, Store
 class ServerTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
-        os.close(DB_FD)
         os.unlink(DB_PATH)
 
     def setUp(self):


### PR DESCRIPTION
## Summary
- fail server startup when the JWT_SECRET env var is missing
- document required JWT_SECRET in README and add regression tests
- fix tests to close temporary SQLite database file descriptor

## Testing
- `pytest server/Servidor/tests/test_missing_jwt_secret.py`
- `pytest server/Servidor/tests/test_login_pytest.py`
- `pytest server/Servidor/tests/test_server.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2b246d1548320ac1ce9856336083a