### PR TITLE
feat: allow API base URL via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ Compila usando el flavor deseado:
 ./gradlew assembleProdRelease # usa PROD_BASE_URL
 ```
 
+### Configurar la URL de la API en los frontends
+
+Las interfaces web leen la dirección de la API desde la variable de entorno `API_BASE` (o `VITE_API_BASE` en el caso del proyecto basado en Vite).
+
+- **Panel de administración y cliente:**
+
+  ```bash
+  cd server/admin-frontend   # o server/client-frontend
+  npm install
+  API_BASE=https://mi-servidor/api npm run build
+  ```
+
+- **Frontend React con Vite:**
+
+  ```bash
+  cd server/temp_admin_frontend
+  npm install
+  VITE_API_BASE=https://mi-servidor/api npm run build
+  ```
+
+Durante el despliegue, ajusta estas variables para apuntar al endpoint de tu servidor.
+
 ## Instalación rápida
 
 ```bash

--- a/server/admin-frontend/app.jsx
+++ b/server/admin-frontend/app.jsx
@@ -1,6 +1,6 @@
 const { useState, useEffect } = React;
 
-const API_BASE = '';
+const API_BASE = process.env.API_BASE || '';
 
 async function apiFetch(path, options = {}) {
   const headers = options.headers ? { ...options.headers } : {};

--- a/server/admin-frontend/package.json
+++ b/server/admin-frontend/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Aplicación web de administración para Bizon MDM",
   "scripts": {
+    "build": "esbuild app.jsx --bundle --define:process.env.API_BASE='$API_BASE' --outfile=app.js",
     "test": "echo 'No tests'"
   },
   "keywords": [],

--- a/server/client-frontend/app.jsx
+++ b/server/client-frontend/app.jsx
@@ -2,7 +2,7 @@ const { useState, useEffect } = React;
 const { BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } = Recharts;
 const { motion } = window.framerMotion || {};
 
-const API_BASE = '/api/client';
+const API_BASE = process.env.API_BASE || '/api/client';
 
 async function apiFetch(path, options = {}) {
   const headers = options.headers ? { ...options.headers } : {};

--- a/server/client-frontend/package.json
+++ b/server/client-frontend/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Aplicación web para clientes de Bizon MDM",
   "scripts": {
+    "build": "esbuild app.jsx --bundle --define:process.env.API_BASE='$API_BASE' --outfile=app.js",
     "test": "echo 'No tests'"
   },
   "keywords": [],

--- a/server/temp_admin_frontend/package.json
+++ b/server/temp_admin_frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "VITE_API_BASE=$API_BASE vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/server/temp_admin_frontend/src/App.jsx
+++ b/server/temp_admin_frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-const API_BASE = '';
+const API_BASE = import.meta.env.VITE_API_BASE || '';
 
 async function apiFetch(path, options = {}) {
   const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
- read API base path from `API_BASE` env var in frontends
- inject API_BASE during build via npm scripts
- document API_BASE configuration for deployments

## Testing
- `npm test` in `server/admin-frontend`
- `npm test` in `server/client-frontend`
- `npm test` *(fails: missing script)* in `server/temp_admin_frontend`


------
https://chatgpt.com/codex/tasks/task_b_68a2b4c347908320b01128d8cee5cc06